### PR TITLE
fix(security): validate API token on startup and warn on HTTP transport

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Do not disclose security vulnerabilities publicly. Email [hello@taskade.com](mailto:hello@taskade.com) with details.
+
+## Token Handling
+
+- Store API tokens in environment variables only — never hardcode in source files.
+- `.env` files are gitignored — never commit tokens to version control.
+- Rotate tokens immediately if compromised.
+- Generate tokens at [taskade.com/settings/api](https://www.taskade.com/settings/api).
+
+## Transport Security
+
+- Use HTTPS/TLS for HTTP/SSE mode in production.
+- Tokens passed via query parameters in HTTP mode may be logged by proxies or web servers.
+- The stdio transport (default for Claude Desktop / Cursor) does not expose tokens over the network.

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,0 +1,1 @@
+TASKADE_API_KEY=

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -2,9 +2,41 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 import { TaskadeMCPServer } from './server';
 
+function validateAccessToken(token: string | undefined): string {
+  if (!token) {
+    console.error(
+      'ERROR: TASKADE_API_KEY environment variable is not set.\n\n' +
+        'To fix this:\n' +
+        '1. Generate a Personal Access Token at: https://www.taskade.com/settings/api\n' +
+        '2. Set the environment variable:\n' +
+        '   export TASKADE_API_KEY="your_token_here"\n',
+    );
+    process.exit(1);
+  }
+
+  const trimmedToken = token.trim();
+
+  if (trimmedToken.length === 0) {
+    console.error('ERROR: TASKADE_API_KEY is empty. Please provide a valid token.');
+    process.exit(1);
+  }
+
+  if (trimmedToken.length < 10) {
+    console.error(
+      'ERROR: TASKADE_API_KEY appears to be invalid (too short).\n' +
+        'Please verify your token at: https://www.taskade.com/settings/api',
+    );
+    process.exit(1);
+  }
+
+  return trimmedToken;
+}
+
 async function main() {
+  const accessToken = validateAccessToken(process.env.TASKADE_API_KEY);
+
   const server = new TaskadeMCPServer({
-    accessToken: process.env.TASKADE_API_KEY!,
+    accessToken,
   });
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -4,6 +4,12 @@ import { startHTTPServer } from 'mcp-proxy';
 
 import { TaskadeMCPServer } from './server';
 
+console.error(
+  '\nNote: HTTP/SSE mode passes access tokens via query parameters.\n' +
+    'For production use, ensure this server is behind HTTPS/TLS.\n' +
+    'Tokens in HTTP URLs may be logged or intercepted.\n',
+);
+
 await startHTTPServer({
   createServer: async (req) => {
     const parsedUrl = url.parse(req.url!, true);


### PR DESCRIPTION
## Summary

Adds security hardening for the MCP server: token validation on startup and a transport security notice for HTTP/SSE mode.

Inspired by the security ideas in #8, cherry-picked cleanly without the pnpm migration that would break the existing yarn/CI workflow.

## Changes

| File | Change |
|------|--------|
| `packages/server/src/cli.ts` | Validate `TASKADE_API_KEY` on startup: reject missing, empty, or short tokens with actionable error messages |
| `packages/server/src/http.ts` | Print HTTPS/TLS security notice when running HTTP/SSE mode |
| `packages/server/.env.example` | Environment variable template for onboarding |
| `SECURITY.md` | Token handling, transport security, vulnerability reporting guidelines |

### Token Validation (cli.ts)

Before: a missing `TASKADE_API_KEY` caused a cryptic runtime error deep in the API call.

After: fails fast on startup with an actionable message pointing to `taskade.com/settings/api`.

Validates: not missing, not empty, not suspiciously short (< 10 chars). Trims whitespace.

### HTTP Transport Warning (http.ts)

Prints a security notice on startup when using HTTP/SSE mode, since tokens are passed via query parameters which may be logged by proxies.

### SECURITY.md

Concise security policy: token handling, transport security, vulnerability reporting.

### .env.example

Single-line template for `TASKADE_API_KEY`.

## Relation to #8

PR #8 introduced these security ideas along with a pnpm migration (8,176-line lockfile + pnpm-workspace.yaml) that conflicts with the yarn-based CI. This PR takes only the security improvements, adapted to work cleanly with the existing build system.

## QA

| Check | Result |
|-------|--------|
| `lerna run build` | PASS |
| Token missing | Exits with actionable error |
| Token empty | Exits with error |
| Token too short | Exits with error |
| Valid token | Trims and proceeds |
| HTTP mode warning | Prints on startup |

cc @lxcid