### PR TITLE
feat: add MCP Registry, Smithery, and Docker publishing configs

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@taskade/mcp-server",
   "version": "0.0.1",
+  "mcpName": "io.github.taskade/mcp-server",
   "author": "Prev Wong",
   "license": "MIT",
   "type": "module",

--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.taskade/mcp-server",
+  "description": "Connect Taskade to any AI assistant — 62+ tools for workspaces, projects, tasks, AI agents, templates, media, sharing, and more.",
+  "repository": {
+    "url": "https://github.com/taskade/mcp.git",
+    "source": "github"
+  },
+  "version": "0.0.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@taskade/mcp-server",
+      "version": "0.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Your Taskade API key. Get it from Taskade Settings > API.",
+          "isRequired": true,
+          "isSecret": true,
+          "name": "TASKADE_API_KEY"
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,15 @@
+runtime: node
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - apiKey
+    properties:
+      apiKey:
+        type: string
+        title: "Taskade API Key"
+        description: "Your Taskade API key. Get it from Taskade Settings > API."
+  commandFunction:
+    |-
+    (config) => ({ command: 'npx', args: ['-y', '@taskade/mcp-server', '--token', config.apiKey] })


### PR DESCRIPTION
## Summary

- Add `mcpName` field to `packages/server/package.json` for MCP Registry verification
- Add `packages/server/server.json` manifest for `mcp-publisher` CLI
- Add `smithery.yaml` for Smithery.ai deployment

## Why

Enables publishing to three distribution channels:

| Channel | Config File | Reach |
|---------|-------------|-------|
| [MCP Registry](https://registry.modelcontextprotocol.io) | `server.json` + `mcpName` | Official MCP directory |
| [Smithery.ai](https://smithery.ai) | `smithery.yaml` | MCP server marketplace |
| [Docker MCP Catalog](https://hub.docker.com/mcp) | `Dockerfile` (already merged) | Docker Desktop integration |

## After merge — publishing steps

1. **MCP Registry**: `npm publish --access public`, then `mcp-publisher login && mcp-publisher publish`
2. **Smithery.ai**: Sign in at smithery.ai with GitHub → claim existing listing → redeploy
3. **Docker**: PR already submitted at docker/mcp-registry#1134

## Test plan

- [ ] Verify `server.json` passes schema validation against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [ ] Verify `smithery.yaml` is valid YAML with required `runtime` and `startCommand` fields
- [ ] Verify `mcpName` matches `server.json` name field