### PR TITLE
fix: shorten server.json description for MCP Registry

### DIFF
--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.taskade/mcp-server",
-  "description": "Connect Taskade to any AI assistant — 62+ tools for workspaces, projects, tasks, AI agents, templates, media, sharing, and more.",
+  "description": "Connect Taskade to any AI assistant — 62+ tools for projects, tasks, agents, and more.",
   "repository": {
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"


### PR DESCRIPTION
## Summary
- Shortens `server.json` description from 126 to 88 characters
- MCP Registry validation requires `description` to be ≤ 100 characters
- Unblocks publishing to registry.modelcontextprotocol.io via `mcp-publisher`

🤖 Generated with [Claude Code](https://claude.com/claude-code)