### PR TITLE
chore: add changeset for v0.0.2 release

### DIFF
--- a/.changeset/registry-publishing.md
+++ b/.changeset/registry-publishing.md
@@ -1,0 +1,5 @@
+---
+"@taskade/mcp-server": patch
+---
+
+Add mcpName field, registry configs, Glama metadata, and n8n examples


### PR DESCRIPTION
## Summary
- Adds a changeset to trigger version bump from 0.0.1 → 0.0.2
- The published npm package will then include the `mcpName` field required by the official MCP Registry
- After this is merged, the release workflow will create a "chore: release" PR to bump versions
- Merging that release PR will publish v0.0.2 to npm, unblocking `mcp-publisher publish`

## Why
The MCP Registry validator requires `mcpName` in the published npm package.json. The current v0.0.1 on npm was published before `mcpName` was added (PR #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)