### PR TITLE
fix: exclude sensitive files from npm package, sync versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,8 @@ typings/
 lib/
 dist/
 
-# macOS finder attribute 
+# macOS finder attribute
 .DS_Store
+
+# MCP Registry tokens
+.mcpregistry_*

--- a/packages/server/.npmignore
+++ b/packages/server/.npmignore
@@ -1,3 +1,8 @@
 src
 scripts
 node_modules
+.mcpregistry_*
+.env
+.env.*
+taskade-public.yaml
+tsconfig.json

--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@taskade/mcp-server",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Adds `.mcpregistry_*` tokens to `.gitignore` and `.npmignore` to prevent accidental leakage
- Excludes unnecessary files from npm package: `.env`, `taskade-public.yaml`, `tsconfig.json`
- Syncs `server.json` version to `0.0.2` to match `package.json` (updated by changesets)

## Important
The `NPM_TOKEN` secret in GitHub Actions has **expired**. The v0.0.2 release workflow failed because of this. To unblock MCP Registry publishing:
1. Generate a new npm access token at https://www.npmjs.com/settings/tokens
2. Update the `NPM_TOKEN` secret in GitHub repo settings
3. Re-run the Force Release workflow or push a new changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)