### PR TITLE
feat: switch to OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -1,10 +1,14 @@
 name: Force Release
 on: workflow_dispatch
 
+permissions: {}
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -12,9 +16,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20 
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -24,5 +28,4 @@ jobs:
         run: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,15 @@ on:
     branches:
       - main
 
+permissions: {}
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -15,9 +20,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20 
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -38,5 +43,4 @@ jobs:
         run: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Replaces expired/problematic NPM_TOKEN with OIDC trusted publishing
- npm classic tokens were [revoked Dec 2025](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/), granular tokens have package scope issues
- OIDC is the [recommended approach](https://docs.npmjs.com/trusted-publishers/) — no tokens to manage

## Changes
- Add `permissions: id-token: write` for OIDC authentication
- Add `NPM_CONFIG_PROVENANCE: true` for supply chain security
- Update Node.js 20 → 22 (required for npm trusted publishing)
- Update `actions/setup-node` v3 → v4
- Remove `NPM_TOKEN` / `NODE_AUTH_TOKEN` references
- Set minimal top-level `permissions: {}` for security

## Required: Configure trusted publisher on npmjs.com
After merging, go to **npmjs.com → @taskade/mcp-server → Settings → Trusted Publisher**:
1. Select **GitHub Actions**
2. Repository: `taskade/mcp`
3. Workflow: `release.yml`
4. Save

Then trigger the **Force Release** workflow to publish v0.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)