### PR TITLE
chore(server): bump server.json to 0.0.3 to match published npm version

### DIFF
--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@taskade/mcp-server",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why

`packages/server/server.json` pins version **`0.0.2`**, but `@taskade/mcp-server` on npm only has **`0.0.1`** and **`0.0.3`** (latest) — `0.0.2` was never published.

The official **MCP Registry** validates that `packages[].version` resolves to a real published npm version carrying the matching `mcpName`. With `0.0.2`, `mcp-publisher publish` would **fail validation**. This bump (both the top-level `version` and `packages[0].version` → `0.0.3`) unblocks the Registry publish.

## What this unblocks

Publishing `io.github.taskade/mcp-server` to `registry.modelcontextprotocol.io` — which then auto-cascades to **PulseMCP** (flips its temporary mirror to the canonical entry), and feeds Glama / mcp.so refreshes.

```
npx @modelcontextprotocol/publisher login github   # auths the io.github.taskade namespace
npx @modelcontextprotocol/publisher publish         # from packages/server, reads server.json
```

## Verified
- ✅ npm `@taskade/mcp-server` latest = `0.0.3` (`0.0.2` absent)
- ✅ `mcpName` already present in published package: `io.github.taskade/mcp-server`
- ✅ JSON validates; only the two version strings changed

Context: internal tracker chore(mcp) — Publish to the official MCP Registry.