### PR TITLE
ci(mcp-registry): auto-publish to the official MCP Registry via GitHub OIDC

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,47 @@
+name: Publish to MCP Registry
+
+# Publishes io.github.taskade/mcp-server to the official MCP Registry
+# (https://registry.modelcontextprotocol.io) using GitHub OIDC — no secrets.
+#
+# Trigger:
+#   - automatically when a release tags the server package (changesets pushes a
+#     `@taskade/mcp-server@<version>` tag right after the npm publish succeeds), so
+#     the npm version always exists before we register it.
+#   - manually via "Run workflow" to (re)publish the current npm version.
+#
+# Note: the server.json version is auto-synced from packages/server/package.json
+# at publish time, so it can never drift out of sync with the published npm
+# version again (the registry rejects a version that isn't on npm).
+
+on:
+  push:
+    tags:
+      - "@taskade/mcp-server@*"
+  workflow_dispatch:
+
+jobs:
+  publish-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for GitHub OIDC auth to the registry
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync server.json version to the published npm version
+        run: |
+          node -e "const fs=require('fs');const p='packages/server/server.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));const v=require('./packages/server/package.json').version;s.version=v;(s.packages||[]).forEach(k=>{k.version=v});fs.writeFileSync(p,JSON.stringify(s,null,2)+'\n');console.log('server.json synced to '+v)"
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Authenticate via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        working-directory: packages/server
+        run: mcp-publisher publish

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -35,8 +35,12 @@ jobs:
           node -e "const fs=require('fs');const p='packages/server/server.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));const v=require('./packages/server/package.json').version;s.version=v;(s.packages||[]).forEach(k=>{k.version=v});fs.writeFileSync(p,JSON.stringify(s,null,2)+'\n');console.log('server.json synced to '+v)"
 
       - name: Install mcp-publisher
+        env:
+          # Pinned for reproducible, reviewable releases — bump deliberately.
+          MCP_PUBLISHER_VERSION: v1.7.9
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar -xz -f - mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
 
       - name: Authenticate via GitHub OIDC


### PR DESCRIPTION
"Set once, never touch again" — registers `io.github.taskade/mcp-server` in the official **[MCP Registry](https://registry.modelcontextprotocol.io)** automatically, with **no secrets** (GitHub OIDC).

## Why
The MCP Registry is the canonical index other directories sync from (PulseMCP flips its temporary mirror to the real entry; Glama / mcp.so refresh). Today Taskade isn't in it. This makes registration automatic and self-maintaining.

## How it works
- **Trigger:** the `@taskade/mcp-server@*` tag that changesets pushes right after a successful npm publish (so the npm version always exists before we register it), plus `workflow_dispatch` for manual runs.
- **Auth:** `mcp-publisher login github-oidc` — OIDC, so no PAT/secret is stored. `io.github.taskade/*` is authorized because the workflow runs in a repo under the `taskade` org.
- **Self-healing version:** a step syncs `packages/server/server.json` → `package.json` version at publish time, so `server.json` can never drift out of sync with npm again (the registry rejects a version that isn't published).

## Sequencing with the other PR
- #35 bumps the committed `server.json` to `0.0.3` (fixes the repo + enables a manual publish today).
- This PR keeps it in sync automatically on every future release.

## To go live now (after merging both)
Click **Actions → Publish to MCP Registry → Run workflow** once to register the current `0.0.3`. Every release after that publishes itself.

## Verification
- ✅ `permissions: id-token: write` (required for OIDC), `contents: read`
- ✅ Decoupled — does **not** modify the existing `release.yml` pipeline or its permissions
- ✅ `mcp-publisher` install pinned to the official `modelcontextprotocol/registry` releases
- ✅ npm package already carries `mcpName: io.github.taskade/mcp-server`

Refs: official OIDC publishing guide — https://modelcontextprotocol.io/registry/quickstart