### PR TITLE
docs: canonicalize hosted MCP endpoint to taskade.com/mcp (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ MCP-powered Taskade agent running inside Claude Desktop by Anthropic:
 
 ## Quick Start
 
+> ⚡ **Zero-install (hosted):** point any MCP client that supports **remote servers** at **`https://www.taskade.com/mcp`** and authorize with your Taskade account — it's an OAuth-protected hosted endpoint, so there's nothing to install and no token to copy. Prefer to self-host or use a stdio-only client? Follow the steps below.
+
 ### 1. Get Your API Key
 
 Go to [Taskade Settings > API](https://www.taskade.com/settings/api) and create a Personal Access Token.
@@ -487,7 +489,6 @@ Works with any OpenAPI 3.0+ spec. Generate MCP tools for your own APIs in minute
 
 See [open issues](https://github.com/taskade/mcp/issues) for planned features and improvements.
 
-- **Hosted MCP Endpoint** — `mcp.taskade.com` for zero-install MCP access ([#6](https://github.com/taskade/mcp/issues/6))
 - **Automation & Flow Tools** — Create, enable, and manage workflow automations via MCP
 - **Agent Chat via MCP** — Send messages to AI agents and receive responses
 - **Webhook Triggers** — Receive real-time notifications from Taskade events

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ MCP-powered Taskade agent running inside Claude Desktop by Anthropic:
 
 ## Quick Start
 
-> ⚡ **Zero-install (hosted):** point any MCP client that supports **remote servers** at **`https://www.taskade.com/mcp`** and authorize with your Taskade account — it's an OAuth-protected hosted endpoint, so there's nothing to install and no token to copy. Prefer to self-host or use a stdio-only client? Follow the steps below.
+> ⚡ **Zero-install (hosted):** add **`https://www.taskade.com/mcp`** as a remote MCP server and authorize with your Taskade account — it's an OAuth-protected hosted endpoint, so there's nothing to install and no token to copy. Works today with **Claude** (web, Desktop, mobile) and **Claude Code**; support for more remote clients is rolling out. Prefer to self-host or use another client? Follow the steps below.
 
 ### 1. Get Your API Key
 


### PR DESCRIPTION
Decision: use the **live** hosted endpoint at **`https://taskade.com/mcp`** rather than standing up a separate `mcp.taskade.com` subdomain (no new infra, no redirect/rewrite fragility).

## Verified
`https://taskade.com/mcp` is an **OAuth-protected remote MCP server**:
- `WWW-Authenticate: Bearer realm="mcp"` on unauthenticated requests
- OAuth discovery live at `/.well-known/oauth-authorization-server` (200) + resource metadata under `/mcp/.well-known/oauth-protected-resource`

So remote-capable MCP clients authorize via browser — true zero-install, no API key to copy.

## Changes
- Add a prominent **zero-install hosted-endpoint** callout to Quick Start pointing at `https://taskade.com/mcp`.
- Remove the planned `mcp.taskade.com` roadmap item — superseded by the live endpoint.

Closes #6. cc @deanzaka @lxcid