### PR TITLE
fix: sync version to 0.0.3 and correct root license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@taskade/mcp",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "author": "Prev Wong",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "build": "lerna run build",

--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@taskade/mcp-server",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "transport": {
         "type": "stdio"
       },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,7 +13,7 @@ export class TaskadeMCPServer extends McpServer {
   constructor(opts: TaskadeServerOpts) {
     super({
       name: 'taskade',
-      version: '0.0.1',
+      version: '0.0.3',
       capabilities: {
         resources: {},
         tools: {},


### PR DESCRIPTION
## What & why
Four-way version drift + an incorrect root license, all verified on `main`:

| Source | Before | After |
|---|---|---|
| `packages/server/src/server.ts:16` (self-reported to clients) | `0.0.1` | `0.0.3` |
| `packages/server/server.json` (registry manifest, ×2) | `0.0.2` | `0.0.3` |
| root `package.json` version | `0.0.1` | `0.0.3` |
| root `package.json` license | `UNLICENSED` | `MIT` |

The published npm package is already `0.0.3`; this aligns every other source to it so the server reports the correct version to clients/registries, and fixes the `UNLICENSED` root (the server package + `LICENSE` file are MIT).

## Zero-regression
- Value-only edits (version strings + license); no logic changes.
- Both JSON files validate; `yarn lint` clean.
- Prerequisite for the MCP Registry publish (clean package-ownership/version check).

## Notes
- Optional follow-up: derive `server.ts` version from `package.json` so it can't drift again.