### PR TITLE
ci: publish to the official MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           # Pinned for reproducible, reviewable releases — bump deliberately.
           MCP_PUBLISHER_VERSION: v1.7.9
         run: |
+          set -euo pipefail
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar -xz -f - mcp-publisher
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write # required for mcp-publisher GitHub OIDC login
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,3 +44,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Publishes packages/server/server.json to the official MCP Registry
+      # (registry.modelcontextprotocol.io) using GitHub Actions OIDC — no stored
+      # secrets. Runs under the same condition as the npm publish above so the
+      # registry version tracks the npm release. Requires a one-time manual
+      # namespace seed by a maintainer: `mcp-publisher login github && mcp-publisher publish`.
+      - name: Publish to MCP Registry
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        working-directory: packages/server
+        run: |
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Publish to MCP Registry
         if: steps.changesets.outputs.hasChangesets == 'false'
         working-directory: packages/server
+        env:
+          # Pinned for reproducible, reviewable releases — bump deliberately.
+          MCP_PUBLISHER_VERSION: v1.7.9
         run: |
-          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar -xz -f - mcp-publisher
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish


### PR DESCRIPTION
## What & why
The Taskade server is **not yet in the official MCP Registry** (verified: `registry.modelcontextprotocol.io/v0/servers?search=taskade` → 0 results). The registry is the upstream source most aggregators (Glama, MCPfinder, …) ingest, so listing once propagates discovery ecosystem-wide.

This wires `packages/server/server.json` to publish automatically on release via the `mcp-publisher` CLI using **GitHub Actions OIDC (no stored secrets)**. The assets are already in place — `server.json` (`io.github.taskade/mcp-server`) + `package.json` `mcpName` are the registry ownership handshake.

## Changes
- `release.yml`: add job `permissions` (`id-token: write` for OIDC) + a **Publish to MCP Registry** step gated on the same `hasChangesets == 'false'` condition as the npm publish.

## Zero-regression
- Purely additive CI step; the existing changesets + npm publish path is untouched.
- Step only runs on release (never on PRs). Binary is downloaded at runtime, not added to deps.
- `mcp-publisher_linux_amd64.tar.gz` asset + `login github-oidc` confirmed against registry release `v1.7.9`.

## ⚠️ One-time manual step (maintainer)
Before the first automated run, a maintainer with org access must seed the namespace once:
```bash
cd packages/server
mcp-publisher login github   # browser OAuth → grants io.github.taskade/* namespace
mcp-publisher publish
```

## Depends on
- #38 (version sync) should merge first so the published registry version matches npm.