### PR TITLE
fix: reconcile advertised tool count to 57

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-slim
 
 LABEL maintainer="Taskade <support@taskade.com>"
-LABEL description="Taskade MCP Server — 62+ AI tools for project management via Model Context Protocol"
+LABEL description="Taskade MCP Server — 57 AI tools for project management via Model Context Protocol"
 LABEL org.opencontainers.image.source="https://github.com/taskade/mcp"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ The server starts at `http://localhost:3000` (configure with `PORT` env var). Co
 | `projectCopy` | Copy a project to a folder |
 | `projectComplete` | Mark project as completed |
 | `projectRestore` | Restore a completed project |
-| `projectFromTemplate` | Create project from a template |
 | `projectMembersGet` | List project members |
 | `projectFieldsGet` | Get custom fields for a project |
 | `projectShareLinkGet` | Get the share link |
 | `projectShareLinkEnable` | Enable the share link |
 | `projectBlocksGet` | Get all blocks in a project |
 | `projectTasksGet` | Get all tasks in a project |
+| `folderProjectsGet` | List projects in a folder |
 
 ### Tasks
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp)
 [![License](https://img.shields.io/github/license/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp/blob/main/LICENSE)
 
-**50+ tools** for workspaces, projects, tasks, AI agents, knowledge bases, templates, automations, media, and sharing — all from your AI client.
+**57 tools** for workspaces, projects, tasks, AI agents, knowledge bases, templates, automations, media, and sharing — all from your AI client.
 
 </div>
 
@@ -82,7 +82,7 @@ The server starts at `http://localhost:3000` (configure with `PORT` env var). Co
 
 ---
 
-## Tools (50+)
+## Tools (57)
 
 ### Workspaces
 
@@ -194,7 +194,7 @@ Taskade MCP gives your AI assistant **full access to your workspace** — projec
                          ↓
   ┌──────────────────────────────────┐
   │     Taskade MCP Server           │
-  │     (50+ tools, 7 categories)    │
+  │     (57 tools, 7 categories)     │
   └──────────────────────────────────┘
        ↓              ↓            ↓
   folderCreateAgent  agentKnowledge  agentPublicAccess
@@ -221,7 +221,7 @@ Taskade MCP gives your AI assistant **full access to your workspace** — projec
 
 ### Why Taskade MCP Over Other MCP Servers?
 
-Taskade is the only MCP server that includes **AI agent management** (create, train, deploy agents), **knowledge base training** (attach docs, projects, media), and **OpenAPI codegen** (generate MCP tools from any API spec). 50+ tools across 7 categories.
+Taskade is the only MCP server that includes **AI agent management** (create, train, deploy agents), **knowledge base training** (attach docs, projects, media), and **OpenAPI codegen** (generate MCP tools from any API spec). 57 tools across 7 categories.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Ready-to-use templates for connecting Taskade MCP Server to popular AI and autom
 
 ## n8n
 
-Import [`n8n-taskade-mcp-workflow.json`](./n8n-taskade-mcp-workflow.json) into n8n to create an AI agent with access to all 62+ Taskade tools.
+Import [`n8n-taskade-mcp-workflow.json`](./n8n-taskade-mcp-workflow.json) into n8n to create an AI agent with access to all 57 Taskade tools.
 
 ### Prerequisites
 

--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.taskade/mcp-server",
-  "description": "Connect Taskade to any AI assistant — 62+ tools for projects, tasks, agents, and more.",
+  "description": "Connect Taskade to any AI assistant — 57 tools for projects, tasks, agents, and more.",
   "repository": {
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"


### PR DESCRIPTION
## What & why
The repo advertised **three different tool counts** simultaneously; the real number is **57** (`ENABLED_TASKADE_ACTIONS` in `packages/server/src/constants.ts`).

| Location | Before | After |
|---|---|---|
| `README.md` intro / `## Tools` header / diagram / why-section (×4) | `50+` | `57` |
| `packages/server/server.json` description | `62+` | `57` |
| `Dockerfile` LABEL | `62+` | `57` |
| `examples/README.md` | `62+` | `57` |

The `62+` claims were outright false (>57). One honest number everywhere.

## Zero-regression
- Text/metadata only; `server.json` validates.
- ASCII "HOW TASKADE MCP WORKS" box re-padded so the right border stays aligned.
- **Intentionally left untouched:** `README.md` line ~400 "AI Agents — Custom agents with 22+ tools" describes the *Taskade product* (agents' built-in integrations), not the MCP server's tool count.

## Follow-up (optional)
- Emit the count from `ENABLED_TASKADE_ACTIONS.length` at build time so it can't drift again.