### PR TITLE
docs: lead with Taskade's story (demote n8n, add ToC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Taskade MCP Server
 
-**Connect [Taskade](https://www.taskade.com) to any AI assistant — Claude, Cursor, Windsurf, n8n, and more — via the [Model Context Protocol](https://modelcontextprotocol.io/).**
+**Connect [Taskade](https://www.taskade.com) to any AI assistant — Claude, Cursor, Windsurf, VS Code, and more — via the [Model Context Protocol](https://modelcontextprotocol.io/).**
 
 [![npm](https://img.shields.io/npm/v/@taskade/mcp-server?style=flat-square&color=FF2D60)](https://www.npmjs.com/package/@taskade/mcp-server)
 [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp)
@@ -14,6 +14,22 @@
 
 - [MCP Server](https://github.com/taskade/mcp/tree/main/packages/server) — Connect Taskade to Claude Desktop, Cursor, Windsurf, or any MCP client.
 - [OpenAPI Codegen](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) — Generate MCP tools from any OpenAPI spec — not just Taskade.
+
+---
+
+## Contents
+
+- [Demo](#demo)
+- [Quick Start](#quick-start)
+- [Tools (57)](#tools-57)
+- [Why Taskade MCP?](#why-taskade-mcp)
+- [Agent Recipes](#agent-recipes)
+- [Use Cases](#use-cases)
+- [OpenAPI Codegen](#openapi-codegen)
+- [What is Taskade?](#what-is-taskade)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+- [License](#license)
 
 ---
 
@@ -72,7 +88,7 @@ Add to your Cursor MCP settings:
 }
 ```
 
-### 4. HTTP / SSE Mode (for n8n, custom clients)
+### 4. HTTP / SSE Mode (remote & custom clients)
 
 ```bash
 TASKADE_API_KEY=your-api-key npx @taskade/mcp-server --http
@@ -361,10 +377,6 @@ Automate project creation from templates:
 - "List all templates in my workspace"
 - "Create 5 new client onboarding projects from the Client Template"
 - "Copy the Sprint Retrospective project for this week"
-
-### n8n Automation Integration
-
-Connect Taskade to 400+ apps via n8n workflows. See the [n8n Integration Guide](./N8N_WORKFLOW_GUIDE.md) for setup instructions.
 
 ---
 


### PR DESCRIPTION
## What & why
The README **promoted a converging competitor (n8n)** and cast Taskade as a spoke of n8n's hub ("Connect Taskade to **400+ apps via n8n**"), while also linking a **dead** `N8N_WORKFLOW_GUIDE.md`. This reframes the README around *Taskade as the orchestrator*.

## Changes
- **Tagline:** drop `n8n`, feature `VS Code` instead.
- **Delete** the `### n8n Automation Integration` section + its dead guide link (also fixes the broken link — by deletion).
- **De-brand** `### 4. HTTP / SSE Mode (for n8n…)` → `(remote & custom clients)`.
- **Add a Table of Contents** (444-line file) for navigation + GitHub-anchor SEO.

## Zero-regression
- Markdown only. n8n **compatibility is preserved** — `examples/n8n-taskade-mcp-workflow.json` stays, and HTTP mode still serves any HTTP MCP client. This is editorial positioning, not a capability change.
- Verified: 0 `n8n` references remain in README; 0 `N8N_WORKFLOW_GUIDE` links; all 11 ToC anchors resolve to real `##` headers.
- **glama.json intentionally NOT changed** — its schema (`glama.ai/mcp/schemas/server.json`) permits only `maintainers`; adding description/tags would be schema-invalid.

## Stacked on
- Base is #40 (tool-count). Will auto-retarget to `main` when #40 merges.