### PR TITLE
docs: one-click Add to Cursor / Install in VS Code badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp)
 [![License](https://img.shields.io/github/license/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp/blob/main/LICENSE)
 
-[![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-0098FF?style=flat-square)](cursor://anysphere.cursor-deeplink/mcp/install?name=taskade&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB0YXNrYWRlL21jcC1zZXJ2ZXIiXSwiZW52Ijp7IlRBU0tBREVfQVBJX0tFWSI6IllPVVJfVEFTS0FERV9BUElfS0VZIn19)
+[![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-0098FF?style=flat-square)](cursor://anysphere.cursor-deeplink/mcp/install?name=taskade&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB0YXNrYWRlL21jcC1zZXJ2ZXIiXSwiZW52Ijp7IlRBU0tBREVfQVBJX0tFWSI6InlvdXItYXBpLWtleS1oZXJlIn19)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22taskade%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40taskade%2Fmcp-server%22%5D%2C%22env%22%3A%7B%22TASKADE_API_KEY%22%3A%22%24%7Binput%3Ataskade_api_key%7D%22%7D%7D)
 
 **57 tools** for workspaces, projects, tasks, AI agents, knowledge bases, templates, automations, media, and sharing — all from your AI client.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp)
 [![License](https://img.shields.io/github/license/taskade/mcp?style=flat-square)](https://github.com/taskade/mcp/blob/main/LICENSE)
 
+[![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-0098FF?style=flat-square)](cursor://anysphere.cursor-deeplink/mcp/install?name=taskade&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB0YXNrYWRlL21jcC1zZXJ2ZXIiXSwiZW52Ijp7IlRBU0tBREVfQVBJX0tFWSI6IllPVVJfVEFTS0FERV9BUElfS0VZIn19)
+[![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22taskade%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40taskade%2Fmcp-server%22%5D%2C%22env%22%3A%7B%22TASKADE_API_KEY%22%3A%22%24%7Binput%3Ataskade_api_key%7D%22%7D%7D)
+
 **57 tools** for workspaces, projects, tasks, AI agents, knowledge bases, templates, automations, media, and sharing — all from your AI client.
 
 </div>


### PR DESCRIPTION
## What & why
The Quick Start only showed copy-paste JSON. These deep-link install badges write the `npx @taskade/mcp-server` config straight into the client — the highest-ROI README conversion change.

- **Add to Cursor** → `cursor://anysphere.cursor-deeplink/mcp/install?name=taskade&config=<base64>`
- **Install in VS Code** → `vscode:mcp/install?<url-encoded config>` (prompts for the API key via `${input:…}`)

## Zero-regression
- Markdown only; both configs decode back to the documented `npx` stdio config (verified round-trip).
- Badge images via shields.io (guaranteed render); custom URI schemes are the established MCP-badge pattern (github-mcp-server etc.).

## Deliberately scoped out (would 404 today)
- **Glama / Smithery / MCP-Registry badges** need live listings with known slugs — add them once #39 (registry publish) and the directory listings land (P10). Adding them now would render broken badges.

## Stacked on
- Base #41 → #40 → `main`. Will auto-retarget as the chain merges.