### PR TITLE
fix: Smithery installs (env token) + honest HTTP docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,15 +29,7 @@ Ask the AI agent natural language questions like:
 - "What tasks are overdue?"
 - "Create an AI agent that monitors project deadlines"
 
-### Alternative: HTTP/SSE mode
-
-If you prefer to run the MCP server as a standalone HTTP service:
-
-```bash
-PORT=3001 npx @taskade/mcp-server --http --token YOUR_TASKADE_API_KEY
-```
-
-Then configure the n8n MCP node to use **HTTP Streamable** transport with URL `http://localhost:3001/mcp`.
+> **Note:** The published `@taskade/mcp-server` CLI runs over **stdio** only — configure the n8n MCP Client node with the command `npx -y @taskade/mcp-server` and a `TASKADE_API_KEY` environment variable. The `--http`/`--token` flags are **not** supported by the published CLI. A standalone HTTP/SSE transport is not yet exposed; track the hosted remote endpoint at [#6](https://github.com/taskade/mcp/issues/6).
 
 ## More examples coming soon
 

--- a/examples/n8n-taskade-mcp-workflow.json
+++ b/examples/n8n-taskade-mcp-workflow.json
@@ -43,7 +43,8 @@
       "parameters": {
         "connectionType": "stdio",
         "command": "npx",
-        "arguments": "-y @taskade/mcp-server --token YOUR_TASKADE_API_KEY"
+        "arguments": "-y @taskade/mcp-server",
+        "environments": "TASKADE_API_KEY=YOUR_TASKADE_API_KEY"
       },
       "id": "mcp-taskade",
       "name": "Taskade MCP",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -12,4 +12,4 @@ startCommand:
         description: "Your Taskade API key. Get it from Taskade Settings > API."
   commandFunction:
     |-
-    (config) => ({ command: 'npx', args: ['-y', '@taskade/mcp-server', '--token', config.apiKey] })
+    (config) => ({ command: 'npx', args: ['-y', '@taskade/mcp-server'], env: { TASKADE_API_KEY: config.apiKey } })

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -10,6 +10,5 @@ startCommand:
         type: string
         title: "Taskade API Key"
         description: "Your Taskade API key. Get it from Taskade Settings > API."
-  commandFunction:
-    |-
+  commandFunction: |-
     (config) => ({ command: 'npx', args: ['-y', '@taskade/mcp-server'], env: { TASKADE_API_KEY: config.apiKey } })


### PR DESCRIPTION
## What & why
The published `@taskade/mcp-server` reads **only** the `TASKADE_API_KEY` env var and parses **no CLI args** ([cli.ts](https://github.com/taskade/mcp/blob/main/packages/server/src/cli.ts)). Two places contradicted that:

1. **Smithery installs fail** — `smithery.yaml` passed `['--token', config.apiKey]`, an arg the binary ignores, so every stdio install started tokenless and exited with the `validateAccessToken` error.
2. **n8n example docs** advertised `--http --token` + a `localhost:3001/mcp` URL that the CLI can't produce.

## Changes
- `smithery.yaml`: `commandFunction` now sets `env: { TASKADE_API_KEY: config.apiKey }` (verified the JS evaluates and emits the right env).
- `examples/README.md`: replace the broken `--http --token` block with accurate stdio guidance + a pointer to the hosted-endpoint roadmap (#6).

## Zero-regression
- stdio runtime path unchanged; this only fixes how the token reaches it on Smithery + corrects docs.
- `smithery.yaml` validates as YAML; `commandFunction` returns `{command,args,env}`.

## Scoped out (conflict avoidance)
- The **main README** `### 4. HTTP / SSE Mode` block overlaps #41's edits to the same region — its accuracy fix is deferred to avoid a merge conflict; the real remote story is the hosted endpoint (#6).