### PR TITLE
docs+fix: privacy policy, SECURITY.md hardening, globalThis.fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,8 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
+!.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ See [open issues](https://github.com/taskade/mcp/issues) for planned features an
 
 ## Privacy & Security
 
-Your Taskade API token authorizes the MCP server to call the Taskade public API on your behalf. The server talks **only** to `https://www.taskade.com/api/v1` and sends your data to no third party.
+Your Taskade API token authorizes the MCP server to call the Taskade public API on your behalf. The server talks **only** to `https://www.taskade.com/api/v1` and does not send your data to other third-party services.
 
 - **Privacy** — see the [Taskade Privacy Policy](https://www.taskade.com/privacy).
 - **Security & vulnerability reporting** — see [SECURITY.md](./SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -496,6 +496,16 @@ See [open issues](https://github.com/taskade/mcp/issues) for planned features an
 
 ---
 
+## Privacy & Security
+
+Your Taskade API token authorizes the MCP server to call the Taskade public API on your behalf. The server talks **only** to `https://www.taskade.com/api/v1` and sends your data to no third party.
+
+- **Privacy** — see the [Taskade Privacy Policy](https://www.taskade.com/privacy).
+- **Security & vulnerability reporting** — see [SECURITY.md](./SECURITY.md).
+- Store your token in an environment variable; never commit it.
+
+---
+
 ## Contributing
 
 Help us improve MCP tools, OpenAPI workflows, and agent capabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,17 +2,51 @@
 
 ## Reporting a Vulnerability
 
-Do not disclose security vulnerabilities publicly. Email [hello@taskade.com](mailto:hello@taskade.com) with details.
+**Please report security issues privately — do not open a public issue or PR.**
+
+- Preferred: open a [GitHub private security advisory](https://github.com/taskade/mcp/security/advisories/new) (Security → Report a vulnerability).
+- Or email [hello@taskade.com](mailto:hello@taskade.com) with details and reproduction steps.
+
+We aim to acknowledge reports within **3 business days** and to provide a remediation
+timeline after triage. Please give us a reasonable window to ship a fix before any
+public disclosure. We're happy to credit reporters who request it.
 
 ## Token Handling
 
-- Store API tokens in environment variables only — never hardcode in source files.
+- Store API tokens in environment variables only — never hardcode them in source files.
 - `.env` files are gitignored — never commit tokens to version control.
 - Rotate tokens immediately if compromised.
 - Generate tokens at [taskade.com/settings/api](https://www.taskade.com/settings/api).
 
 ## Transport Security
 
-- Use HTTPS/TLS for HTTP/SSE mode in production.
-- Tokens passed via query parameters in HTTP mode may be logged by proxies or web servers.
-- The stdio transport (default for Claude Desktop / Cursor) does not expose tokens over the network.
+- The stdio transport (default for Claude Desktop / Cursor / VS Code) does not expose tokens over the network.
+- Use HTTPS/TLS for any HTTP-based transport in production.
+- Avoid passing tokens in URL query parameters — they can be logged by proxies and web servers. Prefer the `Authorization` header or environment variables.
+
+## Never Commit Secrets
+
+This is a public repository. Never commit:
+
+```
+.env, .env.*            # environment files
+*.key, *.pem            # private keys / certificates
+*credentials*, *secret* # credential dumps
+.mcpregistry_*          # MCP registry auth tokens
+```
+
+These patterns are covered by `.gitignore` and `packages/server/.npmignore`. Before committing, sanity-check your staged changes:
+
+```bash
+git diff --cached | grep -iE "(token|key|secret|password|credential)" | grep -v placeholder
+```
+
+If you accidentally commit a secret: **do not push** (or if already pushed, rotate the
+credential immediately), then remove it from history and notify a maintainer. See
+[GitHub: removing sensitive data](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository).
+
+## Privacy
+
+Taskade's data practices are described in the [Taskade Privacy Policy](https://www.taskade.com/privacy).
+The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1`)
+using the token you provide; it does not transmit your data to any third party.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ This is a public repository. Never commit:
 .mcpregistry_*          # MCP registry auth tokens
 ```
 
-These patterns are covered by `.gitignore` and `packages/server/.npmignore`. Before committing, sanity-check your staged changes:
+`.env*` files are gitignored (except `.env.example`) and excluded from the npm package; the other patterns above are **not** auto-ignored, so sanity-check your staged changes before committing:
 
 ```bash
 git diff --cached | grep -iE "(token|key|secret|password|credential)" | grep -v placeholder

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ public disclosure. We're happy to credit reporters who request it.
 
 - The stdio transport (default for Claude Desktop / Cursor / VS Code) does not expose tokens over the network.
 - Use HTTPS/TLS for any HTTP-based transport in production.
-- Avoid passing tokens in URL query parameters — they can be logged by proxies and web servers. Prefer the `Authorization` header or environment variables.
+- The HTTP/SSE transport currently passes the token as an `access_token` URL query parameter, which proxies and servers may log. Until a header-based transport is available, prefer **stdio** (token via the `TASKADE_API_KEY` environment variable), especially in production.
 
 ## Never Commit Secrets
 
@@ -35,7 +35,7 @@ This is a public repository. Never commit:
 .mcpregistry_*          # MCP registry auth tokens
 ```
 
-`.env*` files are gitignored (except `.env.example`) and excluded from the npm package; the other patterns above are **not** auto-ignored, so sanity-check your staged changes before committing:
+`.env*` files (except `.env.example`) and `.mcpregistry_*` are gitignored and excluded from the npm package; the key/credential patterns above are **not** auto-ignored, so sanity-check your staged changes before committing:
 
 ```bash
 git diff --cached | grep -iE "(token|key|secret|password|credential)" | grep -v placeholder
@@ -49,4 +49,5 @@ credential immediately), then remove it from history and notify a maintainer. Se
 
 Taskade's data practices are described in the [Taskade Privacy Policy](https://www.taskade.com/privacy).
 The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1`)
-using the token you provide; it does not transmit your data to any third party.
+using the token you provide; it does not send your data to other third-party services. (In
+HTTP/SSE mode the token travels in the request URL and may be logged — prefer stdio.)

--- a/packages/openapi-codegen/src/runtime.ts
+++ b/packages/openapi-codegen/src/runtime.ts
@@ -168,7 +168,7 @@ export class OpenAPIToolRuntimeConfig {
   }
 
   get fetch() {
-    const fetch = this.config.fetch ?? window['fetch'];
+    const fetch = this.config.fetch ?? globalThis.fetch;
 
     if (!fetch) {
       throw new Error('fetch is not defined');

--- a/packages/server/src/tools.generated.ts
+++ b/packages/server/src/tools.generated.ts
@@ -175,7 +175,7 @@ export class OpenAPIToolRuntimeConfig {
   }
 
   get fetch() {
-    const fetch = this.config.fetch ?? window['fetch'];
+    const fetch = this.config.fetch ?? globalThis.fetch;
 
     if (!fetch) {
       throw new Error('fetch is not defined');


### PR DESCRIPTION
## What & why
Three small trust/security wins (one is a Claude Connectors Directory prerequisite):

1. **Privacy Policy** — the README had none (a hard Directory requirement). Adds a **Privacy & Security** section linking the [Taskade Privacy Policy](https://www.taskade.com/privacy) + SECURITY.md.
2. **SECURITY.md hardening** — adds private vulnerability reporting (GitHub advisories) + a ~3-day ack SLA, a never-commit-secrets section with a pre-commit grep, and a privacy pointer. Keeps the existing token/transport notes.
3. **`window['fetch']` → `globalThis.fetch`** in `runtime.ts` — `globalThis` is the standard global (Node 20+ and browsers), and it clears the 2 'critical' findings in the SafeSkill scan (bracket-notation false positives).

## Zero-regression
- `runtime.ts`: 1-line change; `globalThis.fetch` is equivalent to the previous reference on the server's Node 20+ target. `tools.generated.ts` regenerated → **exactly 1 line changed** (the inlined runtime fetch line); 57 tools intact.
- Docs are additive. `yarn lint` clean.

## Stacked on
- Base #44 (annotations) because both regenerate `tools.generated.ts`. Will auto-retarget to `main` when #44 merges.
- Note: the README **Privacy & Security** ToC entry can be added once #41's ToC and this section are both on `main` (trivial follow-up).