### PR TITLE
docs: Windsurf, Cline & VS Code setup guides (closes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,61 @@ Add to your Cursor MCP settings:
 }
 ```
 
-### 4. HTTP / SSE Mode (remote & custom clients)
+### 4. Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json` (or **Settings → Cascade → MCP → Add Server**):
+
+```json
+{
+  "mcpServers": {
+    "taskade": {
+      "command": "npx",
+      "args": ["-y", "@taskade/mcp-server"],
+      "env": {
+        "TASKADE_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+### 5. Cline
+
+In VS Code, open the Cline **MCP Servers** panel → **Configure MCP Servers** and add:
+
+```json
+{
+  "mcpServers": {
+    "taskade": {
+      "command": "npx",
+      "args": ["-y", "@taskade/mcp-server"],
+      "env": {
+        "TASKADE_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+### 6. VS Code
+
+Add a `.vscode/mcp.json` to your workspace (VS Code uses the `servers` key; `${input:…}` prompts for your key on first run):
+
+```json
+{
+  "servers": {
+    "taskade": {
+      "command": "npx",
+      "args": ["-y", "@taskade/mcp-server"],
+      "env": {
+        "TASKADE_API_KEY": "${input:taskade_api_key}"
+      }
+    }
+  }
+}
+```
+
+### 7. HTTP / SSE Mode (remote & custom clients)
 
 ```bash
 TASKADE_API_KEY=your-api-key npx @taskade/mcp-server --http


### PR DESCRIPTION
## What & why
Quick Start documented only **Claude Desktop** and **Cursor**, yet the tagline advertises Windsurf. Closes #16 by adding copy-paste setup for the remaining major clients.

## Changes (README Quick Start)
- **§4 Windsurf** — `~/.codeium/windsurf/mcp_config.json` (or Settings → Cascade → MCP).
- **§5 Cline** — Cline MCP Servers panel config.
- **§6 VS Code** — `.vscode/mcp.json` using VS Code's `servers` key + `${input:…}` secret prompt.
- HTTP/SSE renumbered §4 → §7.

## Zero-regression
- Markdown only; all JSON config blocks validated as parseable.
- Each block mirrors the existing Claude/Cursor stdio stanza (`npx -y @taskade/mcp-server` + `TASKADE_API_KEY`).

Closes #16.

## Stacked on
- Base #42 → #41 → #40 → `main` (README chain). Auto-retargets as the chain merges.