### PR TITLE
fix(ci): npm OIDC trusted publishing in release.yml (unblocks 0.0.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,13 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # npm publishes via OIDC trusted publishing (no tokens) — same config as the
+    # proven force-release.yml. contents/pull-requests are for the changesets
+    # version PR.
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -15,9 +22,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20 
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -38,5 +45,4 @@ jobs:
         run: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## What broke
Release run [27230473355](https://github.com/taskade/mcp/actions/runs/27230473355) failed publishing `0.0.4`: `npm error 404 Not Found - PUT …` on **both** packages — npm's *unauthorized* symptom for scoped packages.

## Root cause
#26 switched npm to **OIDC trusted publishing** ("no more tokens"), and `0.0.3` actually shipped via `force-release.yml` (manual dispatch), which has `id-token: write` + `NPM_CONFIG_PROVENANCE: true` and no token env. The automatic `release.yml` was never converted — it still passed the retired `NPM_TOKEN` and had **no `permissions` block**, so OIDC could not mint a token → 404 on PUT.

## Fix (mirror the proven force-release.yml config)
| | before | after |
|---|---|---|
| job `permissions` | none | `id-token: write`, `contents: write`, `pull-requests: write` |
| setup-node | @v3 / Node 20 | **@v4 / Node 22** (matches force-release) |
| Publish env | `NPM_TOKEN` + `NODE_AUTH_TOKEN` | `NPM_CONFIG_PROVENANCE: true` (OIDC, no tokens) |

## Zero-regression
- YAML validates; changesets version-PR step unchanged.
- Merging this triggers the release run on main — with #49 already merged and no pending changesets, `hasChangesets == 'false'` → Publish runs → **0.0.4 ships**. If anything fails, `force-release.yml` remains the manual fallback.