### PR TITLE
fix(ci): upgrade npm in release workflows (trusted publishing needs >= 11.5.1)

### DIFF
--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -21,6 +21,10 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # npm OIDC trusted publishing requires npm >= 11.5.1; Node 22 bundles npm 10.x.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest && npm --version
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # npm OIDC trusted publishing requires npm >= 11.5.1; Node 22 bundles npm 10.x,
+      # which signs provenance but cannot do the trusted-publishing token exchange
+      # (publish then fails with E404-on-PUT).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest && npm --version
+
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
## Diagnosis (from release run [27230619415](https://github.com/taskade/mcp/actions/runs/27230619415) + force-release [27230718079](https://github.com/taskade/mcp/actions/runs/27230718079))
Both publish paths fail with `npm error 404 Not Found - PUT` **after provenance signing succeeds** — npm's symptom for an unauthenticated publish. Two stacked causes:

1. **npm too old**: trusted publishing requires **npm ≥ 11.5.1**; Node 22 bundles npm 10.x, which signs provenance but can't do the token exchange. → fixed here (`npm install -g npm@latest` in both workflows).
2. **npmjs.com-side trusted publisher likely not configured** for `@taskade/mcp-server` / `@taskade/mcp-openapi-codegen` → requires a package owner in the npm web UI (Settings → Publishing access → add GitHub Actions publisher: org `taskade`, repo `mcp`, workflow `release.yml`).

Evidence that CI publishing never worked: **every force-release.yml run in history is a failure** (incl. May 19) — `0.0.3` appears to have been published manually.

## Zero-regression
- Additive step; YAML validates; no change to the changesets flow.
- Once npmjs.com config exists, the next push to main publishes `0.0.4` automatically; `force-release` stays as manual fallback.