### PR TITLE
docs(readme): direct docs links + ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Works with any OpenAPI 3.0+ spec. Generate MCP tools for your own APIs in minute
 - Agents: [taskade.com/agents](https://www.taskade.com/agents)
 - Templates: [taskade.com/templates](https://www.taskade.com/templates)
 - Community: [taskade.com/community](https://www.taskade.com/community)
-- Developer Docs: [developers.taskade.com](https://developers.taskade.com)
+- Developer Docs: [docs.taskade.com](https://docs.taskade.com)
 - Blog: [taskade.com/blog](https://www.taskade.com/blog)
 
 ---
@@ -493,7 +493,7 @@ See [open issues](https://github.com/taskade/mcp/issues) for planned features an
 - **Agent Chat via MCP** — Send messages to AI agents and receive responses
 - **Webhook Triggers** — Receive real-time notifications from Taskade events
 - **`agent.js`** — Open-source autonomous agent toolkit (coming soon)
-- **TaskOS** — Agent platform at [developers.taskade.com](https://developers.taskade.com)
+- **TaskOS** — Agent platform at [docs.taskade.com](https://docs.taskade.com)
 
 ---
 
@@ -515,6 +515,14 @@ Help us improve MCP tools, OpenAPI workflows, and agent capabilities.
 - [Pull Requests](https://github.com/taskade/mcp/pulls) — Contributions welcome
 - [Community](https://www.taskade.com/community) — Join the Taskade community
 - [Contact](mailto:hello@taskade.com) — hello@taskade.com
+
+---
+
+## More from Taskade
+
+- [Taskade Docs](https://docs.taskade.com) ([source](https://github.com/taskade/docs)) — developer documentation and API reference
+- [Integration Kit](https://github.com/taskade/integrations) — open-source Zapier/n8n actions & triggers
+- [Taskade](https://github.com/taskade/taskade) — platform home, including Genesis, the AI app builder
 
 ---
 


### PR DESCRIPTION
## What

README-only change, two things:

1. **Direct docs links** — both `developers.taskade.com` references (Links section + Roadmap/TaskOS bullet) now point to https://docs.taskade.com directly. `developers.taskade.com` 301-redirects there anyway, so this just skips the redirect hop.
2. **New "More from Taskade" section** (placed before License) cross-linking the rest of the org:
   - [Taskade Docs](https://docs.taskade.com) ([source](https://github.com/taskade/docs)) — developer documentation and API reference
   - [Integration Kit](https://github.com/taskade/integrations) — open-source Zapier/n8n actions & triggers
   - [Taskade](https://github.com/taskade/taskade) — platform home, including Genesis, the AI app builder

Nothing else in the README is touched.

## Why

Taskade's public repos currently don't cross-link. Developers arrive at this repo from the MCP registries, npm (`@taskade/mcp-server`), docs.taskade.com, and awesome-MCP lists — and hit a dead end with no path to the docs source, the integration kit, or the platform repo. This closes the org link graph so the MCP server is a doorway into the rest of the platform, and removes a redirect hop on the docs links while at it.

For context on what that platform is: Taskade Genesis is the AI app builder — one prompt generates a working app backed by your workspace: projects become the database, AI agents the team, automations the execution layer, with 100+ integrations and MCP support. Docs: https://docs.taskade.com

## Zero-regression verification

- [x] Every new/changed URL returns HTTP 200 via `curl -sL -o /dev/null -w "%{http_code}"`:
  - https://docs.taskade.com → 200
  - https://github.com/taskade/docs → 200
  - https://github.com/taskade/integrations → 200
  - https://github.com/taskade/taskade → 200
- [x] `git diff` shows only the intended lines: 2 link substitutions + the new 8-line section (10 insertions, 2 deletions, README.md only)
- [x] No markdown tables modified (no tables in the touched sections; pipe structure unaffected)
- [x] No other sections, files, or formatting touched

cc @deanzaka @lxcid