### PR TITLE
fix(server): point fetch:openapi at the live v1 spec URL

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,7 @@
     "taskade-mcp-server": "bin/cli.mjs"
   },
   "scripts": {
-    "fetch:openapi": "curl -o taskade-public.yaml https://www.taskade.com/api/documentation/yaml",
+    "fetch:openapi": "curl -fsSL -o taskade-public.yaml https://www.taskade.com/api/documentation/v1/yaml",
     "generate:taskade-mcp-tools": "tsx scripts/gen-taskade-mcp-tools.ts",
     "build:cli": "tsx scripts/build-cli.ts",
     "build": "run-s generate:taskade-mcp-tools build:cli && yarn --cwd=../../ lint:fix",


### PR DESCRIPTION
## Why
`yarn fetch:openapi` curls `https://www.taskade.com/api/documentation/yaml` — which now **404s**. The v1 spec moved to `/api/documentation/v1/yaml` (verified 200; v2 lives at `/v2/yaml`). Without this, the v1 spec can't be refreshed.

## What
- Update the URL to `/api/documentation/v1/yaml`.
- Add `curl -fsSL` so a failed fetch **errors loudly** instead of silently overwriting `taskade-public.yaml` with an error page / empty file.

## Zero-regression
- Only the `fetch:openapi` script string changes. **No regeneration in this PR** → `taskade-public.yaml` and `tools.generated.ts` are untouched, so the 57 shipped tools are identical. Verified the new URL returns the v1 OpenAPI doc.