### PR TITLE
docs(readme): move shipped agent-chat + webhooks out of Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,9 +501,9 @@ Works with any OpenAPI 3.0+ spec. Generate MCP tools for your own APIs in minute
 
 See [open issues](https://github.com/taskade/mcp/issues) for planned features and improvements.
 
+**Recently shipped (v0.1.0):** Agent chat (`promptAgent`) and webhook triggers, live now via the [Taskade API v2 tool layer](#agent-chat--webhooks-api-v2-beta).
+
 - **Automation & Flow Tools** — Create, enable, and manage workflow automations via MCP
-- **Agent Chat via MCP** — Send messages to AI agents and receive responses
-- **Webhook Triggers** — Receive real-time notifications from Taskade events
 - **`agent.js`** — Open-source autonomous agent toolkit (coming soon)
 - **TaskOS** — Agent platform at [docs.taskade.com](https://docs.taskade.com)
 


### PR DESCRIPTION
## What

The README Roadmap section still listed **Agent Chat via MCP** and **Webhook Triggers** as *planned* — but both shipped in v0.1.0 and are already documented under [Tools → Agent Chat & Webhooks](#agent-chat--webhooks-api-v2-beta). That's a direct contradiction for anyone reading top-to-bottom.

## Change (docs only)

- Remove the two shipped bullets from Roadmap.
- Add a **"Recently shipped (v0.1.0)"** note linking to the Tools section — kills the contradiction and shows momentum.
- Remaining roadmap items (Automation & Flow Tools, agent.js, TaskOS) are genuinely still upcoming and kept.

cc @deanzaka @lxcid