### PR TITLE
docs(server): fix API-token link to /settings/api

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -23,7 +23,7 @@ Add the taskade mcp server to your client (ie: Cursor):
 }
 ```
 
-> You will need a valid Taskade personal access token, generate one [here](https://www.taskade.com/settings/password)
+> You will need a valid Taskade personal access token, generate one [here](https://www.taskade.com/settings/api)
 
 
 
@@ -51,7 +51,7 @@ For example, to install the server on Claude, edit your `claude_desktop_config.j
     }
 }
 ```
-> You will need a valid Taskade personal access token, generate one [here](https://www.taskade.com/settings/password)
+> You will need a valid Taskade personal access token, generate one [here](https://www.taskade.com/settings/api)
 
 ### Connect Via SSE/Streamable HTTP
 


### PR DESCRIPTION
`packages/server/README.md` (lines 26, 54) sent users to `/settings/password` to generate a Personal Access Token — the wrong page. Every other surface (root README §1, `smithery.yaml`, `server.json`) uses the canonical **Settings > API → `/settings/api`**. This aligns the package README. Docs-only, zero code.

cc @deanzaka @lxcid