### PR TITLE
docs(readme): align name to "Workspace MCP", deep-link guides, qualify full-access claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Taskade MCP Server
 
+> The **Workspace MCP** (`@taskade/mcp-server`) — run your Taskade workspace from any AI client.
+
 **Connect [Taskade](https://www.taskade.com) to any AI assistant — Claude, Cursor, Windsurf, VS Code, and more — via the [Model Context Protocol](https://modelcontextprotocol.io/).**
 
 [![npm](https://img.shields.io/npm/v/@taskade/mcp-server?style=flat-square&color=FF2D60)](https://www.npmjs.com/package/@taskade/mcp-server)
@@ -45,7 +47,7 @@ MCP-powered Taskade agent running inside Claude Desktop by Anthropic:
 | Build Agents via MCP | Automate Workflows | Manage Projects |
 |:---:|:---:|:---:|
 | <img src="https://raw.githubusercontent.com/taskade/taskade/main/media/agents/agent-generator.gif" width="280" alt="Create AI agents from your IDE via Taskade MCP"> | <img src="https://raw.githubusercontent.com/taskade/taskade/main/media/automations/automation-flows.gif" width="280" alt="Automate workflows via Taskade MCP"> | <img src="https://raw.githubusercontent.com/taskade/taskade/main/media/genesis/create-app.gif" width="280" alt="Manage projects and apps via Taskade MCP"> |
-| Create, train, deploy AI agents from Claude/Cursor | Build multi-step automations across 100+ services | Full workspace management from your AI assistant |
+| Create, train, deploy AI agents from Claude/Cursor | Build multi-step automations across 100+ services | Full workspace management from your AI assistant *(paid plans; some endpoints gated on free)* |
 
 ---
 
@@ -279,7 +281,7 @@ Capabilities the v1 API doesn't have: hold a live conversation with an AI agent,
 
 ## Why Taskade MCP?
 
-Taskade MCP gives your AI assistant **full access to your workspace** — projects, tasks, agents, knowledge bases, templates, and automations. Instead of writing API code, describe what you need in natural language.
+Taskade MCP gives your AI assistant **access to your workspace** — projects, tasks, agents, knowledge bases, templates, and automations (on paid plans; some endpoints such as workspace listing are gated for free accounts). Instead of writing API code, describe what you need in natural language.
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -503,6 +505,8 @@ Works with any OpenAPI 3.0+ spec. Generate MCP tools for your own APIs in minute
 - Templates: [taskade.com/templates](https://www.taskade.com/templates)
 - Community: [taskade.com/community](https://www.taskade.com/community)
 - Developer Docs: [docs.taskade.com](https://docs.taskade.com)
+- **Workspace MCP guide:** https://github.com/taskade/docs/blob/main/apis-living-system-development/workspace-mcp.md
+- **Genesis App MCP guide** (a different, hosted surface): https://github.com/taskade/docs/blob/main/apis-living-system-development/genesis-app-mcp.md
 - Blog: [taskade.com/blog](https://www.taskade.com/blog)
 
 ---


### PR DESCRIPTION
## Summary

Three small consistency fixes to the root README: (1) the docs call this server the **Workspace MCP** but the README calls it "Taskade MCP Server" — reads as two products; (2) the README links only the docs home, giving a reader no path to the specific guides; (3) "full access to your workspace" / "Full workspace management" over-promise on free plans (some endpoints are gated).

## What changed

| Location | Before | After |
|----------|--------|-------|
| H1 (L~3) | `# Taskade MCP Server` | + subtitle: "The **Workspace MCP** (`@taskade/mcp-server`)…" |
| Use-case cell (L~48) | "Full workspace management from your AI assistant" | + "*(paid plans; some endpoints gated on free)*" |
| Prose (L~272) | "**full access to your workspace**" | "**access to your workspace**" + plan-gating parenthetical |
| Resources (L~495/535) | only `docs.taskade.com` | + deep-links to the Workspace MCP guide & Genesis App MCP guide |

## Why it matters (the David cohort)

"Taskade MCP Server" vs "Workspace MCP" reads as two products; the reader has no path from the repo to the operator guides; and "full access" sets a false expectation that breaks on a free plan.

## Design lens

Geist — consistency = recognizability. One product, one name, honest expectations.

## Verification / zero-regression

- npm package name unchanged; H1 preserved (subtitle added).
- Both "full access" locations edited (editing only one would leave the README self-contradictory).
- Deep-links use guaranteed-valid `github.com/taskade/docs` source URLs; a maintainer may swap to canonical `docs.taskade.com` slugs.
- Line ~54 hosted block + decision table are owned by **M1**; `packages/server/README.md` by **M3** — not touched here.

## Merge order

Merge **M1 → M2** (both touch the root README, separate hunks).

---
🤖 Authored with Claude Code (multi-agent verified)
