### PR TITLE
docs(server): replace stale package README with a stub linking the canonical sources

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,71 +1,19 @@
-# Taskade MCP Server
+# Taskade MCP Server — Workspace MCP (`@taskade/mcp-server`)
 
-MCP server for Taskade's public API
+The **Workspace MCP** server connects any MCP-compatible AI client (Claude, Cursor, Claude Code, …) to your Taskade workspace, exposing **62 tools** to read and write your projects, tasks, agents, and custom fields.
 
-## Install
+> 📖 **Full documentation lives in the canonical sources — this package README is intentionally a stub to avoid drift.**
 
-Add the taskade mcp server to your client (ie: Cursor):
+- **Setup, all clients, full tool reference:** [taskade/mcp README](https://github.com/taskade/mcp#readme)
+- **Workspace MCP guide:** [docs.taskade.com](https://github.com/taskade/docs/blob/main/apis-living-system-development/workspace-mcp.md)
+- **Which Taskade MCP do I want?** (Workspace vs Genesis App vs Connectors): [Genesis App MCP guide](https://github.com/taskade/docs/blob/main/apis-living-system-development/genesis-app-mcp.md)
 
+## Quick start
 
-```json
-{
-  "mcpServers": {
-      "taskade": {
-          "command": "npx",
-          "args": [
-              "-y", "@taskade/mcp-server"
-          ],
-          "env": {
-              "TASKADE_API_KEY": "INSERT_YOUR_TASKADE_PERSONAL_ACCESS_TOKEN_HERE"
-          }
-      }
-  }
-}
+```sh
+npx -y @taskade/mcp-server
 ```
 
-> You will need a valid Taskade personal access token, generate one [here](https://www.taskade.com/settings/api)
+You'll need a Taskade personal access token — generate one at [https://www.taskade.com/settings/api](https://www.taskade.com/settings/api).
 
-
-
-## Test locally
-
-- Clone this repo: `git clone git@github.com:taskade/mcp.git`
-- Install dependencies: `yarn install`
-- Build: `yarn build`
-- Install server on your MCP client.
-
-For example, to install the server on Claude, edit your `claude_desktop_config.json`:
-
-```json
-{
-    "mcpServers": {
-        "taskade": {
-            "command": "node",
-            "args": [
-                "/path/to/taskade-mcp-repo"
-            ],
-            "env": {
-                "TASKADE_API_KEY": "INSERT_YOUR_TASKADE_PERSONAL_ACCESS_TOKEN_HERE"
-            }
-        }
-    }
-}
-```
-> You will need a valid Taskade personal access token, generate one [here](https://www.taskade.com/settings/api)
-
-### Connect Via SSE/Streamable HTTP
-
-For clients that support connecting MCP servers via SSE/Streamable HTTP (ie: Cursor):
-
-1. Run the local server: `yarn start:server`
-2. Add the SSE endpoint in your client config (ie: `~/.cursor/mcp.json`):
-
-```json
-{
-    "mcpServers": {
-        "taskade": {
-            "url": "http://localhost:3000/sse?access_token=INSERT_YOUR_TASKADE_PERSONAL_ACCESS_TOKEN_HERE"
-        }
-    }
-}
-```
+See the [root README](https://github.com/taskade/mcp#readme) for client configuration (Claude Desktop, Cursor, Claude Code), HTTP/SSE mode, and the complete tool list.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -5,7 +5,7 @@ The **Workspace MCP** server connects any MCP-compatible AI client (Claude, Curs
 > 📖 **Full documentation lives in the canonical sources — this package README is intentionally a stub to avoid drift.**
 
 - **Setup, all clients, full tool reference:** [taskade/mcp README](https://github.com/taskade/mcp#readme)
-- **Workspace MCP guide:** [docs.taskade.com](https://github.com/taskade/docs/blob/main/apis-living-system-development/workspace-mcp.md)
+- **Workspace MCP guide:** [github.com/taskade/docs](https://github.com/taskade/docs/blob/main/apis-living-system-development/workspace-mcp.md)
 - **Which Taskade MCP do I want?** (Workspace vs Genesis App vs Connectors): [Genesis App MCP guide](https://github.com/taskade/docs/blob/main/apis-living-system-development/genesis-app-mcp.md)
 
 ## Quick start


### PR DESCRIPTION
## Summary

`packages/server/README.md` (the npm package README) is stale and thin — "MCP server for Taskade's public API," no tool count, no v2, no surface note — and contradicts the polished root README. npm readers hit it and never reach the real story. Per the roadmap, the fix is **stub-and-link** rather than parity: two full READMEs would only drift again.

## What changed

| Before | After |
|--------|-------|
| Thin standalone README ("MCP server for Taskade's public API"), no tool count / no v2 / raw JSON token placeholder | Concise stub: names it **Workspace MCP**, states **62 tools**, links the root README + Workspace MCP guide + the "which MCP" guide; keeps a minimal quick-start + canonical token link |

## Why it matters (the David cohort)

The npm/package reader gets the correct product name, the real tool count, and one click to the full docs — instead of a contradictory stub.

## Design lens

Geist — one canonical server doc; eliminate the second source of truth that drifts.

## Verification / zero-regression

- Intentional content reduction (stub-and-link is the chosen strategy).
- Token URL is the canonical `https://www.taskade.com/settings/api`.
- No second 62-tool table authored; `package.json` untouched.

## Merge order

Independent of M1. Note: M2 deliberately does NOT touch this file (to avoid a conflict) — M3 carries the correct "Workspace MCP" naming for the package README.

---
🤖 Authored with Claude Code (multi-agent verified)
