### PR TITLE
feat(server): task node + workspace/subspace URL hints in tool results

### DIFF
--- a/.changeset/task-workspace-url-hints.md
+++ b/.changeset/task-workspace-url-hints.md
@@ -1,0 +1,5 @@
+---
+'@taskade/mcp-server': patch
+---
+
+Task and workspace tool results now include canonical Taskade URL hints (task node deep links, space and subspace URLs).

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -121,6 +121,61 @@ export class TaskadeMCPServer extends McpServer {
             ],
           };
         },
+        taskCreate: (response) => {
+          return {
+            content: [
+              { type: 'text', text: JSON.stringify(response) },
+              {
+                type: 'text',
+                text: 'The url to new tasks is in the format of: https://www.taskade.com/d/{projectId}#node-{taskId}. Share the links with the user.',
+              },
+            ],
+          };
+        },
+        taskGet: (response) => {
+          return {
+            content: [
+              { type: 'text', text: JSON.stringify(response) },
+              {
+                type: 'text',
+                text: 'The url to this task is: https://www.taskade.com/d/{projectId}#node-{taskId}. Link it in your response.',
+              },
+            ],
+          };
+        },
+        projectTasksGet: (response) => {
+          return {
+            content: [
+              { type: 'text', text: JSON.stringify(response) },
+              {
+                type: 'text',
+                text: 'The url to tasks is in the format of: https://www.taskade.com/d/{projectId}#node-{taskId}. You should link all tasks in the response to the user.',
+              },
+            ],
+          };
+        },
+        workspacesGet: (response) => {
+          return {
+            content: [
+              { type: 'text', text: JSON.stringify(response) },
+              {
+                type: 'text',
+                text: 'The url to workspaces is in the format of: https://www.taskade.com/spaces/{workspaceId}. You should link all workspaces in the response to the user.',
+              },
+            ],
+          };
+        },
+        workspaceFoldersGet: (response) => {
+          return {
+            content: [
+              { type: 'text', text: JSON.stringify(response) },
+              {
+                type: 'text',
+                text: 'The url to workspace folders is in the format of: https://www.taskade.com/spaces/{workspaceId}/subspaces/{folderId}. You should link all folders in the response to the user.',
+              },
+            ],
+          };
+        },
         folderAgentGet: (response) => {
           return {
             content: [


### PR DESCRIPTION
## What

Extends the existing `normalizeResponse` link-hint mechanism in `packages/server/src/server.ts` to cover tasks and workspaces.

**Already hinted (unchanged):**
- Project tools (`projectGet`, `projectCreate`, `folderProjectsGet`, `meProjectsGet`, ...) → `https://www.taskade.com/d/{projectId}`
- Agent tools (`agentPublicGet`, `publicAgentGet`) → `https://www.taskade.com/a/{publicAgentId}`

**Added in this PR (same structure and phrasing as the existing entries):**

| Tool | URL hint |
|---|---|
| `taskCreate`, `taskGet`, `projectTasksGet` | `https://www.taskade.com/d/{projectId}#node-{taskId}` (task node deep link) |
| `workspacesGet` | `https://www.taskade.com/spaces/{workspaceId}` |
| `workspaceFoldersGet` | `https://www.taskade.com/spaces/{workspaceId}/subspaces/{folderId}` |

Closes #1

**Intentionally out of scope** from the issue's checklist: the internal tabs/slugs (`/media`, `/agents`, `/flows`) and `https://www.taskade.com/flows/*` deep links — there is no public API surface (no flow tools) for these yet, so there is nothing to attach hints to.

Includes a patch changeset for `@taskade/mcp-server`.

## Test plan

- `yarn build` passes; working tree clean after post-commit rebuild (regen produces no diff)
- `yarn lint` passes
- `yarn test` passes (17 tests, 3 files)
- Verified all five keys (`taskCreate`, `taskGet`, `projectTasksGet`, `workspacesGet`, `workspaceFoldersGet`) exist verbatim as tool names in `tools.generated.ts` (note: the list-tasks tool is `projectTasksGet`; there is no `tasksGet`)
- New entries mirror the existing entry structure exactly (e.g. `taskGet` mirrors `projectGet`)