### PR TITLE
docs: acknowledge API v2 in privacy claims; fix stale 57-tool references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-slim
 
 LABEL maintainer="Taskade <support@taskade.com>"
-LABEL description="Taskade MCP Server — 57 AI tools for project management via Model Context Protocol"
+LABEL description="Taskade MCP Server — 62 AI tools for project management via Model Context Protocol"
 LABEL org.opencontainers.image.source="https://github.com/taskade/mcp"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ See [open issues](https://github.com/taskade/mcp/issues) for planned features an
 
 ## Privacy & Security
 
-Your Taskade API token authorizes the MCP server to call the Taskade public API on your behalf. The server talks **only** to `https://www.taskade.com/api/v1` and does not send your data to other third-party services.
+Your Taskade API token authorizes the MCP server to call the Taskade public API on your behalf. The server talks **only** to the Taskade public API — `https://www.taskade.com/api/v1` and `https://www.taskade.com/api/v2` — and does not send your data to other third-party services.
 
 - **Privacy** — see the [Taskade Privacy Policy](https://www.taskade.com/privacy).
 - **Security & vulnerability reporting** — see [SECURITY.md](./SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,6 @@ credential immediately), then remove it from history and notify a maintainer. Se
 ## Privacy
 
 Taskade's data practices are described in the [Taskade Privacy Policy](https://www.taskade.com/privacy).
-The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1`
-and `https://www.taskade.com/api/v2`) using the token you provide; it does not send your data
-to other third-party services. (In
+The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1` and `https://www.taskade.com/api/v2`)
+using the token you provide; it does not send your data to other third-party services. (In
 HTTP/SSE mode the token travels in the request URL and may be logged — prefer stdio.)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,7 @@ credential immediately), then remove it from history and notify a maintainer. Se
 ## Privacy
 
 Taskade's data practices are described in the [Taskade Privacy Policy](https://www.taskade.com/privacy).
-The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1`)
-using the token you provide; it does not send your data to other third-party services. (In
+The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1`
+and `https://www.taskade.com/api/v2`) using the token you provide; it does not send your data
+to other third-party services. (In
 HTTP/SSE mode the token travels in the request URL and may be logged — prefer stdio.)

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Ready-to-use templates for connecting Taskade MCP Server to popular AI and autom
 
 ## n8n
 
-Import [`n8n-taskade-mcp-workflow.json`](./n8n-taskade-mcp-workflow.json) into n8n to create an AI agent with access to all 57 Taskade tools.
+Import [`n8n-taskade-mcp-workflow.json`](./n8n-taskade-mcp-workflow.json) into n8n to create an AI agent with access to all 62 Taskade tools.
 
 ### Prerequisites
 


### PR DESCRIPTION
Docs-only accuracy sweep. Since the v2 tool layer shipped (`setupToolsV2` in `packages/server/src/server.ts`), the server calls both `https://www.taskade.com/api/v1` and `https://www.taskade.com/api/v2`, and the total tool count is 62 (57 v1 + 5 v2). Four doc lines still claimed v1-only traffic or 57 tools.

## Changes

| File | Before | After |
| --- | --- | --- |
| `README.md` (Privacy & Security) | The server talks **only** to `https://www.taskade.com/api/v1` and does not send your data to other third-party services. | The server talks **only** to the Taskade public API — `https://www.taskade.com/api/v1` and `https://www.taskade.com/api/v2` — and does not send your data to other third-party services. |
| `SECURITY.md` (Privacy) | The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1`) using the token you provide; … | The MCP server sends requests only to the Taskade public API (`https://www.taskade.com/api/v1` and `https://www.taskade.com/api/v2`) using the token you provide; … |
| `Dockerfile` (LABEL description) | Taskade MCP Server — 57 AI tools … | Taskade MCP Server — 62 AI tools … |
| `examples/README.md` (n8n) | … an AI agent with access to all 57 Taskade tools. | … an AI agent with access to all 62 Taskade tools. |

The only-Taskade guarantee is unchanged: v2 traffic also goes exclusively to `www.taskade.com` — no data is sent to any other third-party service.

Intentionally untouched: the two `CHANGELOG.md` entries saying "v1's 57 tools are unchanged" — those are historical release notes accurately describing the v1 layer's count when v2 shipped.

## Test plan

- `git grep -E '(talks|sends|requests) .*only .*api/v1'` — the one remaining match (SECURITY.md:51) names both API bases on the same line; no claim omits v2.
- `git grep -nE '57 (AI )?(Taskade )?tools|all 57' -- '*.md' Dockerfile` — only the two historical CHANGELOG entries remain (accurate v1-layer counts, left as-is).
- CI: `yarn build` (regen + bundle, tree stays clean), `yarn lint`, `yarn test` (17/17) all pass locally.

Docs only — no runtime changes, no changeset.
