### PR TITLE
fix(server): report the real package version to MCP clients

### DIFF
--- a/.changeset/server-real-version.md
+++ b/.changeset/server-real-version.md
@@ -1,0 +1,5 @@
+---
+'@taskade/mcp-server': patch
+---
+
+MCP clients now see the real package version (was hardcoded 0.0.3). Releasing also publishes the canonical package README stub (#64) and corrected API-token link (#61) to npm.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import fetch from 'node-fetch';
 
+import { version } from '../package.json';
 import { setupTools } from './tools.generated';
 import { setupToolsV2 } from './tools.v2.generated';
 
@@ -14,7 +15,7 @@ export class TaskadeMCPServer extends McpServer {
   constructor(opts: TaskadeServerOpts) {
     super({
       name: 'taskade',
-      version: '0.0.3',
+      version,
       capabilities: {
         resources: {},
         tools: {},


### PR DESCRIPTION
## Summary

MCP clients connecting to `@taskade/mcp-server` were told the server is version `0.0.3` — the `McpServer` constructor in `packages/server/src/server.ts` hardcoded it while the published package is `0.1.1`. The version is now sourced from `packages/server/package.json` via `import { version } from '../package.json'` (`resolveJsonModule` + `moduleResolution: bundler` already enabled). esbuild inlines and tree-shakes the JSON named import, so the published bundle carries the literal string — dev (`tsx src/`) and the shipped `bin/cli.mjs` agree, with no runtime file reads and no `createRequire` relative-path divergence. Inspected `http.ts` (SSE path) and `cli.ts` for other hardcoded versions: none found.

## Why it matters

Beyond correct client-side telemetry/debugging, this unblocks cutting `0.1.2`: the merged-but-unpublished npm README stub (#64) and the corrected API-token link (#61) finally ship to npm with the release the included changeset produces.

## Test plan

- `yarn build` — passes; working tree clean after build (regen + lint:fix produce no diff)
- `yarn lint` — passes
- `yarn test` — 17/17 pass
- Bundle check: `grep -n '0.1.1' packages/server/bin/cli.mjs` → `var version = "0.1.1"` (inlined from package.json), used at the `McpServer` super call; zero occurrences of `0.0.3` in the bundle
- Boot test: `TASKADE_API_KEY=... node packages/server/bin/cli.mjs` starts clean ("Taskade MCP Server running on stdio") and stays up
- MCP handshake: `initialize` over stdio returns `serverInfo: {"name":"taskade","version":"0.1.1"}`
- `npx tsc --noEmit -p packages/server` — exit 0