### PR TITLE
feat(codegen): derive idempotentHint + openWorldHint, allow per-action annotation overrides

### DIFF
--- a/.changeset/wild-hints-complete.md
+++ b/.changeset/wild-hints-complete.md
@@ -1,0 +1,6 @@
+---
+'@taskade/mcp-openapi-codegen': patch
+'@taskade/mcp-server': patch
+---
+
+Generated tools now carry the full MCP annotation set: derived idempotentHint and openWorldHint:false alongside readOnly/destructive hints; per-action overrides supported.

--- a/packages/openapi-codegen/src/codegen.test.ts
+++ b/packages/openapi-codegen/src/codegen.test.ts
@@ -1,0 +1,94 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { describe, expect, it } from 'vitest';
+
+import { codegen } from './codegen';
+
+const document = {
+  openapi: '3.0.0',
+  info: { title: 'Tiny API', version: '1.0.0' },
+  paths: {
+    '/things': {
+      get: { operationId: 'thingList', description: 'List things', responses: {} },
+      post: { operationId: 'thingCreate', description: 'Create a thing', responses: {} },
+    },
+    '/things/{thingId}': {
+      put: { operationId: 'thingUpdate', description: 'Update a thing', responses: {} },
+      delete: { operationId: 'thingDelete', description: 'Delete a thing', responses: {} },
+    },
+  },
+} as OpenAPIV3.Document;
+
+/**
+ * Extracts the annotation hints for a named tool out of the generated
+ * (prettier-formatted) source.
+ */
+const hintsFor = (output: string, toolName: string) => {
+  const chunk = output
+    .split('server.tool(')
+    .find((part) => part.trimStart().startsWith(`"${toolName}"`));
+  expect(chunk, `generated output contains tool ${toolName}`).toBeDefined();
+
+  const hints: Record<string, boolean> = {};
+  for (const key of ['readOnlyHint', 'destructiveHint', 'idempotentHint', 'openWorldHint']) {
+    const match = chunk?.match(new RegExp(`${key}:\\s*(true|false)`));
+    expect(match, `${toolName} carries ${key}`).toBeTruthy();
+    hints[key] = match?.[1] === 'true';
+  }
+  return hints;
+};
+
+describe('codegen derived annotations', () => {
+  it('derives the full MCP hint set from the HTTP method', async () => {
+    const output = await codegen({ document });
+
+    expect(hintsFor(output, 'thingList')).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(hintsFor(output, 'thingCreate')).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+    expect(hintsFor(output, 'thingUpdate')).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(hintsFor(output, 'thingDelete')).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it('lets a per-action config override any derived hint, including to false', async () => {
+    const output = await codegen({
+      document,
+      actions: {
+        // A POST that is actually idempotent (e.g. taskComplete-style actions).
+        thingCreate: { idempotentHint: true },
+        // An explicit `false` override must beat a derived `true`.
+        thingDelete: { destructiveHint: false },
+      },
+    });
+
+    expect(hintsFor(output, 'thingCreate')).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(hintsFor(output, 'thingDelete')).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+});

--- a/packages/openapi-codegen/src/codegen.ts
+++ b/packages/openapi-codegen/src/codegen.ts
@@ -12,7 +12,23 @@ type ActionConfig = Partial<{
   title: string;
   description: string;
   normalizer: (args: any) => any;
+  /**
+   * Explicit MCP annotation overrides. When set, they beat the values derived
+   * from the HTTP method (e.g. a POST action that is actually idempotent can
+   * set `idempotentHint: true`).
+   */
+  readOnlyHint: boolean;
+  destructiveHint: boolean;
+  idempotentHint: boolean;
+  openWorldHint: boolean;
 }>;
+
+const ANNOTATION_HINT_KEYS = [
+  'readOnlyHint',
+  'destructiveHint',
+  'idempotentHint',
+  'openWorldHint',
+] as const;
 
 const isActionsEnabled = (isActionsEnabledOpt: IsActionsEnabledOpt, actionName: string) => {
   if (typeof isActionsEnabledOpt === 'function') {
@@ -81,23 +97,39 @@ export const codegen = async (opts: CodegenOpts) => {
     }
 
     // Derive MCP tool annotations from the HTTP method: GET/HEAD are read-only,
-    // DELETE is destructive. A human-friendly title can be supplied via opts.actions.
+    // DELETE is destructive, GET/HEAD/PUT/DELETE are idempotent per HTTP
+    // semantics (POST is not). openWorldHint is always false: this server only
+    // talks to the Taskade API — a closed world. A human-friendly title and
+    // explicit hint overrides can be supplied via opts.actions.
     const method = tool.method.toUpperCase();
     const annotations: Record<string, any> = {
       readOnlyHint: method === 'GET' || method === 'HEAD',
       destructiveHint: method === 'DELETE',
+      idempotentHint: ['GET', 'HEAD', 'PUT', 'DELETE'].includes(method),
+      openWorldHint: false,
     };
 
-    const actionTitle = opts.actions?.[tool.name]?.title;
+    const actionConfig = opts.actions?.[tool.name];
+
+    // Explicit per-action overrides beat derived values. Undefined-checked so
+    // an explicit `false` override wins too.
+    for (const hint of ANNOTATION_HINT_KEYS) {
+      const override = actionConfig?.[hint];
+      if (override !== undefined) {
+        annotations[hint] = override;
+      }
+    }
+
+    const actionTitle = actionConfig?.title;
     if (actionTitle) {
       annotations.title = actionTitle;
     }
 
-    const description = opts.actions?.[tool.name]?.description ?? tool.description;
+    const description = actionConfig?.description ?? tool.description;
 
     const toolArgs = [`"${tool.name}"`, `"${description}"`, generateToolInputFromParsedTool(tool)];
 
-    // annotations always carry read-only/destructive hints, so always include them
+    // annotations always carry the derived hint set, so always include them
     toolArgs.push(JSON.stringify(annotations));
 
     toolArgs.push(`async (args) => {

--- a/packages/server/src/tools.generated.ts
+++ b/packages/server/src/tools.generated.ts
@@ -223,6 +223,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Create Workspace Project',
     },
     async (args) => {
@@ -240,7 +242,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'workspacesGet',
     'Get all workspaces for a user',
     z.object({}).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get All Workspaces' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get All Workspaces',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'workspacesGet',
@@ -259,6 +267,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Workspace Folders',
     },
     async (args) => {
@@ -279,6 +289,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Project Details',
     },
     async (args) => {
@@ -296,7 +308,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'projectComplete',
     'Mark the project as completed',
     z.object({ projectId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Complete Project' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Complete Project',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'projectComplete',
@@ -312,7 +330,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'projectRestore',
     'Restore project',
     z.object({ projectId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Restore Project' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Restore Project',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'projectRestore',
@@ -332,7 +356,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       projectTitle: z.string().min(1).optional(),
       projectId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Copy Project' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Copy Project',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'projectCopy',
@@ -355,6 +385,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Create New Project',
     },
     async (args) => {
@@ -375,6 +407,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Create Project from Template',
     },
     async (args) => {
@@ -399,6 +433,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Project Members',
     },
     async (args) => {
@@ -416,7 +452,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'projectFieldsGet',
     'Get all fields for a project',
     z.object({ projectId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Project Fields' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Project Fields',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'projectFieldsGet',
@@ -435,6 +477,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Project Share Link',
     },
     async (args) => {
@@ -455,6 +499,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Enable Project Share Link',
     },
     async (args) => {
@@ -477,7 +523,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       after: z.string().uuid().optional(),
       before: z.string().uuid().optional(),
     }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Project Blocks' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Project Blocks',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'projectBlocksGet',
@@ -498,7 +550,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       after: z.string().uuid().optional(),
       before: z.string().uuid().optional(),
     }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Project Tasks' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Project Tasks',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'projectTasksGet',
@@ -514,7 +572,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskGet',
     'Get task with id',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Task Details' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Task Details',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskGet',
@@ -530,7 +594,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskDelete',
     'Delete a task in a project',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: true, title: 'Delete Task' },
+    {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Delete Task',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskDelete',
@@ -551,7 +621,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       projectId: z.string(),
       taskId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Update Task' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Update Task',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskPut',
@@ -567,7 +643,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskComplete',
     'Complete a task in a project',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Complete Task' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Complete Task',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskComplete',
@@ -586,6 +668,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Mark Task Incomplete',
     },
     async (args) => {
@@ -627,7 +711,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
         .max(20),
       projectId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Create New Task' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Create New Task',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskCreate',
@@ -652,7 +742,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       projectId: z.string(),
       taskId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Move Task' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Move Task',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskMove',
@@ -668,7 +764,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskAssigneesGet',
     'Get the assignees of a task',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Task Assignees' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Task Assignees',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskAssigneesGet',
@@ -691,6 +793,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Update Task Assignees',
     },
     async (args) => {
@@ -715,6 +819,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Remove Task Assignees',
     },
     async (args) => {
@@ -732,7 +838,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskGetDate',
     'Get the date of a task',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Task Date' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Task Date',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskGetDate',
@@ -748,7 +860,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskDeleteDate',
     'Delete date of a task',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: true, title: 'Remove Task Date' },
+    {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Remove Task Date',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskDeleteDate',
@@ -792,7 +910,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       projectId: z.string(),
       taskId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Set Task Date' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Set Task Date',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskPutDate',
@@ -808,7 +932,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskNoteGet',
     'Get the note of a task',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Task Note' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Task Note',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskNoteGet',
@@ -829,7 +959,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       projectId: z.string(),
       taskId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Update Task Note' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Update Task Note',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskNotePut',
@@ -845,7 +981,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'taskNoteDelete',
     'Delete the note of a task',
     z.object({ projectId: z.string(), taskId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: true, title: 'Delete Task Note' },
+    {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Delete Task Note',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'taskNoteDelete',
@@ -864,6 +1006,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get All Task Field Values',
     },
     async (args) => {
@@ -884,6 +1028,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Task Field Value',
     },
     async (args) => {
@@ -904,6 +1050,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Delete Task Field Value',
     },
     async (args) => {
@@ -929,6 +1077,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Set Task Field Value',
     },
     async (args) => {
@@ -949,6 +1099,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Projects in Folder',
     },
     async (args) => {
@@ -969,6 +1121,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Generate AI Agent from Prompt',
     },
     async (args) => {
@@ -1162,7 +1316,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       ]),
       folderId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Create AI Agent' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Create AI Agent',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'folderCreateAgent',
@@ -1185,6 +1345,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Agents in Folder',
     },
     async (args) => {
@@ -1209,6 +1371,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Media in Folder',
     },
     async (args) => {
@@ -1233,6 +1397,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Project Templates',
     },
     async (args) => {
@@ -1254,7 +1420,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
       page: z.number().default(1),
       sort: z.enum(['viewed-asc', 'viewed-desc']).default('viewed-desc'),
     }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get My Projects' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get My Projects',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'meProjectsGet',
@@ -1273,6 +1445,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Enable Agent Public Access',
     },
     async (args) => {
@@ -1290,7 +1464,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'agentGet',
     'Get agent with id',
     z.object({ agentId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Agent Details' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Agent Details',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'agentGet',
@@ -1306,7 +1486,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'deleteAgent',
     'Delete an agent',
     z.object({ agentId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: true, title: 'Delete Agent' },
+    {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Delete Agent',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'deleteAgent',
@@ -1402,7 +1588,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
         .optional(),
       agentId: z.string(),
     }).shape,
-    { readOnlyHint: false, destructiveHint: false, title: 'Update Agent' },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Update Agent',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'agentUpdate',
@@ -1418,7 +1610,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'agentPublicGet',
     'Get public agent',
     z.object({ agentId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Public Agent' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Public Agent',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'agentPublicGet',
@@ -1455,6 +1653,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Update Public Agent',
     },
     async (args) => {
@@ -1475,6 +1675,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Add Knowledge Project to Agent',
     },
     async (args) => {
@@ -1495,6 +1697,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Add Knowledge Media to Agent',
     },
     async (args) => {
@@ -1515,6 +1719,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Remove Knowledge Project from Agent',
     },
     async (args) => {
@@ -1535,6 +1741,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: false,
       destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Remove Knowledge Media from Agent',
     },
     async (args) => {
@@ -1559,6 +1767,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Agent Conversations',
     },
     async (args) => {
@@ -1579,6 +1789,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Agent Conversation',
     },
     async (args) => {
@@ -1596,7 +1808,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'mediaGet',
     'Get media with id',
     z.object({ mediaId: z.string() }).shape,
-    { readOnlyHint: true, destructiveHint: false, title: 'Get Media Details' },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Get Media Details',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'mediaGet',
@@ -1612,7 +1830,13 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'mediaDelete',
     'Delete a media',
     z.object({ mediaId: z.string() }).shape,
-    { readOnlyHint: false, destructiveHint: true, title: 'Delete Media' },
+    {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Delete Media',
+    },
     async (args) => {
       return await config.executeToolCall({
         name: 'mediaDelete',
@@ -1631,6 +1855,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     {
       readOnlyHint: true,
       destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
       title: 'Get Public Agent by Public ID',
     },
     async (args) => {

--- a/packages/server/src/tools.v2.generated.ts
+++ b/packages/server/src/tools.v2.generated.ts
@@ -223,6 +223,8 @@ export const setupToolsV2 = (server: McpServer, opts: OpenAPIToolRuntimeConfigOp
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Chat with an AI Agent',
     },
     async (args) => {
@@ -247,6 +249,8 @@ export const setupToolsV2 = (server: McpServer, opts: OpenAPIToolRuntimeConfigOp
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'List Agent Conversations',
     },
     async (args) => {
@@ -267,6 +271,8 @@ export const setupToolsV2 = (server: McpServer, opts: OpenAPIToolRuntimeConfigOp
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Get Agent Conversation',
     },
     async (args) => {
@@ -297,6 +303,8 @@ export const setupToolsV2 = (server: McpServer, opts: OpenAPIToolRuntimeConfigOp
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Subscribe to a Webhook',
     },
     async (args) => {
@@ -317,6 +325,8 @@ export const setupToolsV2 = (server: McpServer, opts: OpenAPIToolRuntimeConfigOp
     {
       readOnlyHint: false,
       destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
       title: 'Unsubscribe from a Webhook',
     },
     async (args) => {


### PR DESCRIPTION
Completes the MCP tool-annotation set started in #44 (derived `readOnlyHint`/`destructiveHint`, called out there as a hard prerequisite for the Claude Connectors Directory). The codegen now derives all four spec hints per tool and supports explicit per-action overrides.

## Derivation table (HTTP method → hints)

| Method | readOnlyHint | destructiveHint | idempotentHint | openWorldHint |
|--------|--------------|-----------------|----------------|---------------|
| GET    | true         | false           | true           | false         |
| HEAD   | true         | false           | true           | false         |
| PUT    | false        | false           | true           | false         |
| DELETE | false        | true            | true           | false         |
| POST   | false        | false           | false          | false         |

- `idempotentHint` follows HTTP semantics (GET/HEAD/PUT/DELETE idempotent, POST not). Per the MCP spec it is only meaningful when `readOnlyHint` is false — it is emitted uniformly, but the values that matter are on the PUT/DELETE/POST tools.
- `openWorldHint: false` everywhere: this server talks only to the Taskade API — a closed world.

## Per-action overrides

`ActionConfig` now accepts explicit `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`; an undefined-checked override beats the derived value (so an explicit `false` wins too). This makes future exceptions expressible — e.g. a POST like `taskComplete` is arguably idempotent. No overrides are set in this PR; all generated values are purely derived.

## Zero-regression proof (A1)

Scripted comparison of per-tool annotation objects between `24f491b` and the regenerated files:

```
packages/server/src/tools.generated.ts: old=57 new=57 (expected 57) sameNameSet=true
  preexisting annotations changed: 0; tools with unexpected new keys: 0
packages/server/src/tools.v2.generated.ts: old=5 new=5 (expected 5) sameNameSet=true
  preexisting annotations changed: 0; tools with unexpected new keys: 0
A1 PASS
```

Every pre-existing `readOnlyHint`/`destructiveHint`/`title` value is byte-identical; the only additions per tool are `idempotentHint` and `openWorldHint`.

## Changeset

Patch bump for `@taskade/mcp-openapi-codegen` and `@taskade/mcp-server`: "Generated tools now carry the full MCP annotation set: derived idempotentHint and openWorldHint:false alongside readOnly/destructive hints; per-action overrides supported."

## Test plan

- `yarn build` regenerates both `tools.generated.ts` (57 tools) and `tools.v2.generated.ts` (5 tools); working tree clean after commit.
- `yarn lint` clean.
- `yarn test`: 19 tests / 4 files pass, including new `codegen.test.ts` (in-memory OpenAPI doc with one GET/POST/PUT/DELETE; asserts all four derived hints per method, plus override cases including an explicit-false override) (A2).
- A1 comparison script output above.
