### PR TITLE
feat(server): space bundle export/import — Genesis .tsk app kits (66 → 68)

### DIFF
--- a/.changeset/spec-refresh-bundle-tools.md
+++ b/.changeset/spec-refresh-bundle-tools.md
@@ -1,0 +1,5 @@
+---
+'@taskade/mcp-server': minor
+---
+
+Refresh the vendored v1 OpenAPI spec (14 months stale) and enable Genesis space-bundle tools: `bundleExport` (export a space as a SpaceBundleData v1 JSON bundle — agents, automations, projects, templates, apps) and `bundleImport` (install a bundle into a workspace) — 66 → 68 tools. The refreshed spec also updates several existing tool schemas from a year of API evolution (richer Date descriptions, new agent persona enums, nullable agent fields, pagination-cursor tweaks). Twelve malformed root-relative `$ref`s in the upstream-generated YAML were patched to absolute pointers so the spec dereferences cleanly. The raw ZIP/`.tsk` and media binary endpoints (`bundleExportZip`, `bundleImportZip`, `mediaUpload`, `mediaDownload`, `mediaDownloadAll`) are not enabled — they exchange raw binary payloads and need a handwritten wrapper.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Export and import whole spaces as portable JSON bundles (SpaceBundleData v1 — 
 | `bundleExport` | Export a space (subspace / app) as a JSON bundle — agents, automations, projects, templates, apps |
 | `bundleImport` | Import a JSON bundle into a workspace — validated against SpaceBundleData v1, all items installed into the target workspace |
 
-> **Note:** imports are subject to your plan's server-side limits — an over-quota import fails with a `4XX` error. The raw ZIP/`.tsk` and media file endpoints (`bundleExportZip`, `bundleImportZip`, `mediaUpload`, `mediaDownload`) exchange binary payloads and are not exposed as tools yet.
+> **Note:** imports are subject to your plan's server-side limits — an over-quota import fails with a `4XX` error. The raw ZIP/`.tsk` and media file endpoints (`bundleExportZip`, `bundleImportZip`, `mediaUpload`, `mediaDownload`, `mediaDownloadAll`) exchange binary payloads and are not exposed as tools yet.
 
 ### Personal
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Add to Cursor](https://img.shields.io/badge/Add_to-Cursor-0098FF?style=flat-square)](cursor://anysphere.cursor-deeplink/mcp/install?name=taskade&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkB0YXNrYWRlL21jcC1zZXJ2ZXIiXSwiZW52Ijp7IlRBU0tBREVfQVBJX0tFWSI6InlvdXItYXBpLWtleS1oZXJlIn19)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22taskade%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40taskade%2Fmcp-server%22%5D%2C%22env%22%3A%7B%22TASKADE_API_KEY%22%3A%22%24%7Binput%3Ataskade_api_key%7D%22%7D%7D)
 
-**66 tools** for workspaces, projects, tasks, AI agents, agent chat, webhooks, knowledge bases, templates, media, and sharing — all from your AI client.
+**68 tools** for workspaces, projects, tasks, AI agents, agent chat, webhooks, knowledge bases, templates, media, space bundles, and sharing — all from your AI client.
 
 </div>
 
@@ -26,7 +26,7 @@
 
 - [Demo](#demo)
 - [Quick Start](#quick-start)
-- [Tools (66)](#tools-66)
+- [Tools (68)](#tools-68)
 - [Why Taskade MCP?](#why-taskade-mcp)
 - [Agent Recipes](#agent-recipes)
 - [Use Cases](#use-cases)
@@ -169,7 +169,7 @@ The server starts at `http://localhost:3000` (configure with `PORT` env var). Co
 
 ---
 
-## Tools (66)
+## Tools (68)
 
 ### Workspaces
 
@@ -259,6 +259,17 @@ Create, manage, and publish autonomous AI agents with custom knowledge and tools
 | `mediaGet` | Get media details |
 | `mediaDelete` | Delete a media file |
 
+### Space Bundles
+
+Export and import whole spaces as portable JSON bundles (SpaceBundleData v1 — the "Workspace DNA" format behind Genesis `.tsk` app kits). A bundle carries a space's agents, automations, projects, templates, and apps; media files are excluded from the JSON format.
+
+| Tool | Description |
+|------|-------------|
+| `bundleExport` | Export a space (subspace / app) as a JSON bundle — agents, automations, projects, templates, apps |
+| `bundleImport` | Import a JSON bundle into a workspace — validated against SpaceBundleData v1, all items installed into the target workspace |
+
+> **Note:** imports are subject to your plan's server-side limits — an over-quota import fails with a `4XX` error. The raw ZIP/`.tsk` and media file endpoints (`bundleExportZip`, `bundleImportZip`, `mediaUpload`, `mediaDownload`) exchange binary payloads and are not exposed as tools yet.
+
 ### Personal
 
 | Tool | Description |
@@ -299,7 +310,7 @@ Taskade MCP gives your AI assistant **access to your workspace** — projects, t
                          ↓
   ┌──────────────────────────────────┐
   │     Taskade MCP Server           │
-  │     (66 tools, 8 categories)     │
+  │     (68 tools, 9 categories)     │
   └──────────────────────────────────┘
        ↓              ↓            ↓
   folderCreateAgent  agentKnowledge  agentPublicAccess
@@ -326,7 +337,7 @@ Taskade MCP gives your AI assistant **access to your workspace** — projects, t
 
 ### Why Taskade MCP Over Other MCP Servers?
 
-Taskade is the only MCP server that includes **AI agent management** (create, train, deploy agents), **knowledge base training** (attach docs, projects, media), and **OpenAPI codegen** (generate MCP tools from any API spec). 66 tools across 8 categories.
+Taskade is the only MCP server that includes **AI agent management** (create, train, deploy agents), **knowledge base training** (attach docs, projects, media), and **OpenAPI codegen** (generate MCP tools from any API spec). 68 tools across 9 categories.
 
 ---
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,6 +1,6 @@
 # Taskade MCP Server — Workspace MCP (`@taskade/mcp-server`)
 
-The **Workspace MCP** server connects any MCP-compatible AI client (Claude, Cursor, Claude Code, …) to your Taskade workspace, exposing **68 tools** to read and write your projects, tasks, agents, custom fields, and space bundles.
+The **Workspace MCP** server connects any MCP-compatible AI client (Claude, Cursor, Claude Code, …) to your Taskade workspace, exposing tools to read and write your projects, tasks, agents, custom fields, and space bundles.
 
 > 📖 **Full documentation lives in the canonical sources — this package README is intentionally a stub to avoid drift.**
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,6 +1,6 @@
 # Taskade MCP Server — Workspace MCP (`@taskade/mcp-server`)
 
-The **Workspace MCP** server connects any MCP-compatible AI client (Claude, Cursor, Claude Code, …) to your Taskade workspace, exposing **62 tools** to read and write your projects, tasks, agents, and custom fields.
+The **Workspace MCP** server connects any MCP-compatible AI client (Claude, Cursor, Claude Code, …) to your Taskade workspace, exposing **68 tools** to read and write your projects, tasks, agents, custom fields, and space bundles.
 
 > 📖 **Full documentation lives in the canonical sources — this package README is intentionally a stub to avoid drift.**
 

--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.taskade/mcp-server",
-  "description": "Connect Taskade to any AI assistant — 66 tools: projects, tasks, agents, agent chat, signed webhooks.",
+  "description": "Connect Taskade to any AI assistant — 68 tools: projects, tasks, agents, agent chat, signed webhooks, space bundles.",
   "repository": {
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -67,6 +67,10 @@ export const ENABLED_TASKADE_ACTIONS = [
   'mediaGet',
   'mediaDelete',
 
+  // Bundles
+  'bundleExport',
+  'bundleImport',
+
   // Me
   'meProjectsGet',
 ];
@@ -140,6 +144,10 @@ export const HUMANIZED_TASKADE_ACTIONS = {
   mediasGet: 'Get Media in Folder',
   mediaGet: 'Get Media Details',
   mediaDelete: 'Delete Media',
+
+  // Bundles
+  bundleExport: 'Export Space Bundle',
+  bundleImport: 'Import Space Bundle',
 
   // Me
   meProjectsGet: 'Get My Projects',

--- a/packages/server/src/tools.generated.ts
+++ b/packages/server/src/tools.generated.ts
@@ -520,8 +520,8 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     z.object({
       projectId: z.string(),
       limit: z.number().default(100),
-      after: z.string().uuid().optional(),
-      before: z.string().uuid().optional(),
+      after: z.string().optional(),
+      before: z.string().optional(),
     }).shape,
     {
       readOnlyHint: true,
@@ -546,9 +546,9 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     'Get all tasks for a project',
     z.object({
       projectId: z.string(),
-      limit: z.number().default(100),
-      after: z.string().uuid().optional(),
-      before: z.string().uuid().optional(),
+      limit: z.number().lte(1000).default(100),
+      after: z.string().optional(),
+      before: z.string().optional(),
     }).shape,
     {
       readOnlyHint: true,
@@ -884,26 +884,88 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
     z.object({
       start: z
         .object({
-          date: z.string().regex(new RegExp('^\\d{4}-\\d{2}-\\d{2}$')),
+          date: z
+            .string()
+            .regex(new RegExp('^\\d{4}-\\d{2}-\\d{2}$'))
+            .describe('ISO date format (YYYY-MM-DD), e.g. "2021-12-31"'),
           time: z
             .union([
-              z.string().regex(new RegExp('^(?:[0-1][0-9]|[2][0-3]):[0-5][0-9](?::[0-5][0-9])?$')),
-              z.null(),
+              z
+                .string()
+                .regex(new RegExp('^(?:[0-1][0-9]|[2][0-3]):[0-5][0-9](?::[0-5][0-9])?$'))
+                .describe(
+                  'Optional time component in 24-hour format (HH:MM:SS), e.g. "15:30:45". Can be null or omitted for date-only representations',
+                ),
+              z
+                .null()
+                .describe(
+                  'Optional time component in 24-hour format (HH:MM:SS), e.g. "15:30:45". Can be null or omitted for date-only representations',
+                ),
             ])
+            .describe(
+              'Optional time component in 24-hour format (HH:MM:SS), e.g. "15:30:45". Can be null or omitted for date-only representations',
+            )
             .optional(),
-          timezone: z.union([z.string(), z.null()]).optional(),
+          timezone: z
+            .union([
+              z
+                .string()
+                .describe(
+                  'Optional timezone identifier (IANA timezone name), e.g. "America/New_York", "Asia/Singapore". Can be null or omitted for timezone-naive representations',
+                ),
+              z
+                .null()
+                .describe(
+                  'Optional timezone identifier (IANA timezone name), e.g. "America/New_York", "Asia/Singapore". Can be null or omitted for timezone-naive representations',
+                ),
+            ])
+            .describe(
+              'Optional timezone identifier (IANA timezone name), e.g. "America/New_York", "Asia/Singapore". Can be null or omitted for timezone-naive representations',
+            )
+            .optional(),
         })
         .strict(),
       end: z
         .object({
-          date: z.string().regex(new RegExp('^\\d{4}-\\d{2}-\\d{2}$')),
+          date: z
+            .string()
+            .regex(new RegExp('^\\d{4}-\\d{2}-\\d{2}$'))
+            .describe('ISO date format (YYYY-MM-DD), e.g. "2021-12-31"'),
           time: z
             .union([
-              z.string().regex(new RegExp('^(?:[0-1][0-9]|[2][0-3]):[0-5][0-9](?::[0-5][0-9])?$')),
-              z.null(),
+              z
+                .string()
+                .regex(new RegExp('^(?:[0-1][0-9]|[2][0-3]):[0-5][0-9](?::[0-5][0-9])?$'))
+                .describe(
+                  'Optional time component in 24-hour format (HH:MM:SS), e.g. "15:30:45". Can be null or omitted for date-only representations',
+                ),
+              z
+                .null()
+                .describe(
+                  'Optional time component in 24-hour format (HH:MM:SS), e.g. "15:30:45". Can be null or omitted for date-only representations',
+                ),
             ])
+            .describe(
+              'Optional time component in 24-hour format (HH:MM:SS), e.g. "15:30:45". Can be null or omitted for date-only representations',
+            )
             .optional(),
-          timezone: z.union([z.string(), z.null()]).optional(),
+          timezone: z
+            .union([
+              z
+                .string()
+                .describe(
+                  'Optional timezone identifier (IANA timezone name), e.g. "America/New_York", "Asia/Singapore". Can be null or omitted for timezone-naive representations',
+                ),
+              z
+                .null()
+                .describe(
+                  'Optional timezone identifier (IANA timezone name), e.g. "America/New_York", "Asia/Singapore". Can be null or omitted for timezone-naive representations',
+                ),
+            ])
+            .describe(
+              'Optional timezone identifier (IANA timezone name), e.g. "America/New_York", "Asia/Singapore". Can be null or omitted for timezone-naive representations',
+            )
+            .optional(),
         })
         .strict()
         .optional(),
@@ -1156,6 +1218,23 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
                         .describe(
                           'Human-readable name of the command in title case. This should probably be a verb.',
                         ),
+                      description: z
+                        .union([
+                          z
+                            .string()
+                            .describe(
+                              'Short summary for discovery (e.g. progressive disclosure / skill listing). The full instruction stays in `prompt`.',
+                            ),
+                          z
+                            .null()
+                            .describe(
+                              'Short summary for discovery (e.g. progressive disclosure / skill listing). The full instruction stays in `prompt`.',
+                            ),
+                        ])
+                        .describe(
+                          'Short summary for discovery (e.g. progressive disclosure / skill listing). The full instruction stays in `prompt`.',
+                        )
+                        .optional(),
                       prompt: z
                         .string()
                         .min(1)
@@ -1218,7 +1297,7 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
                   .string()
                   .describe('The language of the agent, e.g. en-US, zh-Hans')
                   .optional(),
-                inputPlaceholder: z.string().optional(),
+                inputPlaceholder: z.union([z.string(), z.null()]).optional(),
               })
               .strict(),
           })
@@ -1297,6 +1376,42 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
                   'ViralAgent',
                   'SOPOnboardingAgent',
                   'PressReleaseAgent',
+                  'Designer',
+                  'Brainstormer',
+                  'Builder',
+                  'ResearchAnalyst',
+                  'OperationsManager',
+                  'CodeReviewer',
+                  'LeadScorer',
+                  'ContactEnricher',
+                  'ContentStrategist',
+                  'DealMover',
+                  'Estimator',
+                  'DigitalTwin',
+                  'WatchFloorBriefer',
+                  'AnomalySpotter',
+                  'RestockAdvisor',
+                  'AppDoctor',
+                  'RenewalChaser',
+                  'WinBackSpecialist',
+                  'NoShowRescuer',
+                  'AbandonedCartRecoverer',
+                  'ReviewResponder',
+                  'TestimonialHarvester',
+                  'SponsorshipManager',
+                  'CourseLaunchStrategist',
+                  'CurriculumAuthor',
+                  'PersonalizedRoadmapGenerator',
+                  'DispatchCoordinator',
+                  'ProviderNetworkBuilder',
+                  'ClaimsClerk',
+                  'ListingMarketer',
+                  'GrantWriter',
+                  'ComplianceKeeper',
+                  'LeadQualifier',
+                  'ClientOnboardingConcierge',
+                  'PipelineReporter',
+                  'LearnerCoach',
                 ]),
                 avatar: z
                   .object({
@@ -1520,6 +1635,23 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
                   .describe(
                     'Human-readable name of the command in title case. This should probably be a verb.',
                   ),
+                description: z
+                  .union([
+                    z
+                      .string()
+                      .describe(
+                        'Short summary for discovery (e.g. progressive disclosure / skill listing). The full instruction stays in `prompt`.',
+                      ),
+                    z
+                      .null()
+                      .describe(
+                        'Short summary for discovery (e.g. progressive disclosure / skill listing). The full instruction stays in `prompt`.',
+                      ),
+                  ])
+                  .describe(
+                    'Short summary for discovery (e.g. progressive disclosure / skill listing). The full instruction stays in `prompt`.',
+                  )
+                  .optional(),
                 prompt: z
                   .string()
                   .min(1)
@@ -1582,7 +1714,7 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
             .string()
             .describe('The language of the agent, e.g. en-US, zh-Hans')
             .optional(),
-          inputPlaceholder: z.string().optional(),
+          inputPlaceholder: z.union([z.string(), z.null()]).optional(),
         })
         .strict()
         .optional(),
@@ -1643,8 +1775,67 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
             .object({
               title: z.string().optional(),
               description: z.string().optional(),
+              image: z
+                .union([
+                  z
+                    .object({
+                      ownerID: z.string(),
+                      ownerType: z.union([z.string().min(1), z.null()]).optional(),
+                      id: z.string(),
+                      namespace: z.string(),
+                      extension: z.string(),
+                      s3KeyOriginal: z.string(),
+                      userID: z.union([z.number(), z.null()]).optional(),
+                      spaceID: z.union([z.string().min(1), z.null()]).optional(),
+                      documentID: z.union([z.string().min(1), z.null()]).optional(),
+                      nodeID: z.union([z.string().min(1), z.null()]).optional(),
+                      size: z.number(),
+                      mimetype: z.string(),
+                      metadata: z.object({}).catchall(z.any()).optional(),
+                      type: z.string().optional(),
+                      name: z.string().optional(),
+                      description: z.string().optional(),
+                    })
+                    .catchall(z.any()),
+                  z.null(),
+                ])
+                .optional(),
             })
             .strict()
+            .optional(),
+          color: z.string().optional(),
+          launcherIcon: z
+            .union([
+              z.object({ type: z.literal('emoji'), value: z.string().min(1) }).strict(),
+              z
+                .object({
+                  type: z.literal('custom'),
+                  image: z.union([
+                    z
+                      .object({
+                        ownerID: z.string(),
+                        ownerType: z.union([z.string().min(1), z.null()]).optional(),
+                        id: z.string(),
+                        namespace: z.string(),
+                        extension: z.string(),
+                        s3KeyOriginal: z.string(),
+                        userID: z.union([z.number(), z.null()]).optional(),
+                        spaceID: z.union([z.string().min(1), z.null()]).optional(),
+                        documentID: z.union([z.string().min(1), z.null()]).optional(),
+                        nodeID: z.union([z.string().min(1), z.null()]).optional(),
+                        size: z.number(),
+                        mimetype: z.string(),
+                        metadata: z.object({}).catchall(z.any()).optional(),
+                        type: z.string().optional(),
+                        name: z.string().optional(),
+                        description: z.string().optional(),
+                      })
+                      .catchall(z.any()),
+                    z.null(),
+                  ]),
+                })
+                .strict(),
+            ])
             .optional(),
         })
         .strict(),
@@ -1844,6 +2035,63 @@ export const setupTools = (server: McpServer, opts: OpenAPIToolRuntimeConfigOpts
         method: 'DELETE',
         input: args,
         pathParamKeys: ['mediaId'],
+        queryParamKeys: [],
+      });
+    },
+  );
+  server.tool(
+    'bundleExport',
+    'Export a space (subspace / app) as a JSON bundle (SpaceBundleData v1). Returns all agents, automations, projects, templates, and apps. Media items are excluded — use the ZIP export or download media separately via the media endpoints.',
+    z.object({ spaceId: z.string() }).shape,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+      title: 'Export Space Bundle',
+    },
+    async (args) => {
+      return await config.executeToolCall({
+        name: 'bundleExport',
+        path: '/bundles/{spaceId}/export',
+        method: 'GET',
+        input: args,
+        pathParamKeys: ['spaceId'],
+        queryParamKeys: [],
+      });
+    },
+  );
+  server.tool(
+    'bundleImport',
+    'Import a JSON bundle (agents, automations, projects, templates, apps) into a workspace. The bundle is validated against the SpaceBundleData v1 schema and all items are installed into the target workspace. Media items are not supported — use the ZIP import or upload media separately via the media endpoints after import.',
+    z.object({
+      bundleData: z
+        .object({
+          version: z.literal('1').describe('Bundle format version.'),
+          items: z
+            .record(z.object({ type: z.string() }).catchall(z.any()))
+            .describe(
+              'Map of bundle items keyed by ID. Each item has a `type` field: space-bundle-flow-item, space-bundle-project-item, space-bundle-agent-item, space-bundle-template-item, space-bundle-media-item, space-bundle-app-item.',
+            ),
+        })
+        .strict()
+        .describe('The Workspace DNA bundle to import (SpaceBundleData v1).'),
+      workspaceId: z.string(),
+    }).shape,
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+      title: 'Import Space Bundle',
+    },
+    async (args) => {
+      return await config.executeToolCall({
+        name: 'bundleImport',
+        path: '/bundles/{workspaceId}/import',
+        method: 'POST',
+        input: args,
+        pathParamKeys: ['workspaceId'],
         queryParamKeys: [],
       });
     },

--- a/packages/server/taskade-public.yaml
+++ b/packages/server/taskade-public.yaml
@@ -1,8 +1,10 @@
 openapi: 3.0.3
 info:
-  title: Taskade Public API
-  description: Taskade, the AI-Powered Productivity Platform.
-  version: 0.1.0
+  title: Taskade Public API (v1)
+  description: "Taskade REST API (v1, GA) — stable, resource-style endpoints with
+    full task and project CRUD. The AI-native workspace platform: build apps,
+    deploy agents, automate workflows."
+  version: 1.0.0
 components:
   securitySchemes:
     oAuthAuthorizationCode:
@@ -16,6 +18,39 @@ components:
       type: http
       scheme: bearer
   schemas:
+    BundleInstallation:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the bundle installation.
+        projectCount:
+          type: number
+          description: Number of projects installed.
+        flowCount:
+          type: number
+          description: Number of automations installed.
+        agentCount:
+          type: number
+          description: Number of agents installed.
+        templateCount:
+          type: number
+          description: Number of templates installed.
+        mediaCount:
+          type: number
+          description: Number of media files installed.
+        appCount:
+          type: number
+          description: Number of apps installed.
+      required:
+        - id
+        - projectCount
+        - flowCount
+        - agentCount
+        - templateCount
+        - mediaCount
+        - appCount
+      additionalProperties: false
     Project:
       type: object
       properties:
@@ -81,12 +116,10 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         text:
           type: string
         parentId:
           type: string
-          format: uuid
         completed:
           type: boolean
           default: false
@@ -110,13 +143,19 @@ components:
         date:
           type: string
           pattern: ^\d{4}-\d{2}-\d{2}$
+          description: ISO date format (YYYY-MM-DD), e.g. "2021-12-31"
         time:
           type: string
           pattern: ^(?:[0-1][0-9]|[2][0-3]):[0-5][0-9](?::[0-5][0-9])?$
           nullable: true
+          description: Optional time component in 24-hour format (HH:MM:SS), e.g.
+            "15:30:45". Can be null or omitted for date-only representations
         timezone:
           type: string
           nullable: true
+          description: Optional timezone identifier (IANA timezone name), e.g.
+            "America/New_York", "Asia/Singapore". Can be null or omitted for
+            timezone-naive representations
       required:
         - date
       additionalProperties: false
@@ -142,6 +181,11 @@ components:
                     minLength: 1
                     description: Human-readable name of the command in title case. This should
                       probably be a verb.
+                  description:
+                    type: string
+                    nullable: true
+                    description: Short summary for discovery (e.g. progressive disclosure / skill
+                      listing). The full instruction stays in `prompt`.
                   prompt:
                     type: string
                     minLength: 1
@@ -222,6 +266,7 @@ components:
               description: The language of the agent, e.g. en-US, zh-Hans
             inputPlaceholder:
               type: string
+              nullable: true
           required:
             - commands
           additionalProperties: false
@@ -277,6 +322,188 @@ components:
                   type: string
                   enum:
                     - Note
+                fillerConfig:
+                  anyOf:
+                    - type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - string.translate
+                        sourceRef:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - field
+                                fieldPath:
+                                  type: string
+                              required:
+                                - type
+                                - fieldPath
+                              additionalProperties: false
+                        targetLang:
+                          type: string
+                      required:
+                        - type
+                        - sourceRef
+                        - targetLang
+                      additionalProperties: false
+                    - type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - string.summarize
+                        sourceRef:
+                          $ref: "#/components/schemas/Field/properties/data/anyOf/1/properties/fillerConfig/anyOf/0/properties/sourceRef"
+                        additionalInstructions:
+                          type: string
+                      required:
+                        - type
+                        - sourceRef
+                      additionalProperties: false
+                    - type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - string.extract
+                        sourceRef:
+                          $ref: "#/components/schemas/Field/properties/data/anyOf/1/properties/fillerConfig/anyOf/0/properties/sourceRef"
+                        entity:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - email_address
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - first_name
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - last_name
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - phone_number
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - domain_name
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - link
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - date
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - time
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - year
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - custom
+                                instructions:
+                                  type: string
+                              required:
+                                - type
+                                - instructions
+                              additionalProperties: false
+                      required:
+                        - type
+                        - sourceRef
+                        - entity
+                      additionalProperties: false
+                    - type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - string.custom
+                        instructions:
+                          type: string
+                      required:
+                        - type
+                        - instructions
+                      additionalProperties: false
+                    - type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - Select.pick
+                        sourceRef:
+                          $ref: "#/components/schemas/Field/properties/data/anyOf/1/properties/fillerConfig/anyOf/0/properties/sourceRef"
+                        permittedOptionIds:
+                          type: array
+                          items:
+                            type: string
+                        additionalInstructions:
+                          type: string
+                      required:
+                        - type
+                        - sourceRef
+                        - permittedOptionIds
+                      additionalProperties: false
               required:
                 - type
               additionalProperties: false
@@ -343,6 +570,8 @@ components:
                     additionalProperties: false
                 defaultOption:
                   type: string
+                fillerConfig:
+                  $ref: "#/components/schemas/Field/properties/data/anyOf/1/properties/fillerConfig"
               required:
                 - displayName
                 - type
@@ -446,6 +675,87 @@ components:
                     - string
                 description:
                   type: string
+                fillerConfig:
+                  $ref: "#/components/schemas/Field/properties/data/anyOf/1/properties/fillerConfig"
+                constraints:
+                  type: object
+                  properties:
+                    unique:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum:
+                            - unique
+                      required:
+                        - type
+                      additionalProperties: false
+                  additionalProperties: false
+              required:
+                - displayName
+                - type
+              additionalProperties: false
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - Password
+                title:
+                  type: string
+                description:
+                  type: string
+                hashAlgorithm:
+                  type: string
+                  enum:
+                    - bcrypt
+                    - argon2
+                    - scrypt
+                    - pbkdf2
+                  default: bcrypt
+                minLength:
+                  type: integer
+                  minimum: 1
+                  default: 8
+                maxLength:
+                  type: integer
+                  minimum: 1
+              required:
+                - type
+              additionalProperties: false
+            - type: object
+              properties:
+                displayName:
+                  type: string
+                  minLength: 1
+                type:
+                  type: string
+                  enum:
+                    - Rating
+                max:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+                  default: 5
+                icon:
+                  type: string
+                  enum:
+                    - star
+                    - heart
+                  default: star
+              required:
+                - displayName
+                - type
+              additionalProperties: false
+            - type: object
+              properties:
+                displayName:
+                  type: string
+                  minLength: 1
+                type:
+                  type: string
+                  enum:
+                    - Relationship
               required:
                 - displayName
                 - type
@@ -532,6 +842,19 @@ components:
                 type:
                   type: string
                   enum:
+                    - Media
+                title:
+                  type: string
+                description:
+                  type: string
+              required:
+                - type
+              additionalProperties: false
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
                     - Unimplemented
               required:
                 - type
@@ -554,7 +877,6 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         text:
           type: string
         completed:
@@ -596,9 +918,69 @@ components:
                         - gpt-4o
                         - gpt-4-turbo
                         - gpt-4o-mini
+                        - gpt-4.1
+                        - gpt-4.1-mini
+                        - gpt-4.1-nano
                         - o3-mini:low
                         - o3-mini:medium
                         - o3-mini:high
+                        - o4-mini:low
+                        - o4-mini:medium
+                        - o4-mini:high
+                        - openai/gpt-4o
+                        - openai/gpt-4o-mini
+                        - openai/gpt-4.1
+                        - openai/gpt-4.1-mini
+                        - openai/gpt-4.1-nano
+                        - openai/gpt-5
+                        - openai/gpt-5:high
+                        - openai/gpt-5-mini
+                        - openai/gpt-5-mini:high
+                        - openai/gpt-5-nano
+                        - openai/gpt-5-nano:high
+                        - openai/gpt-5.1
+                        - openai/gpt-5.1:low
+                        - openai/gpt-5.1:medium
+                        - openai/gpt-5.1:high
+                        - openai/gpt-5.1-codex
+                        - openai/gpt-5.1-codex:low
+                        - openai/gpt-5.1-codex:medium
+                        - openai/gpt-5.1-codex:high
+                        - openai/gpt-5.1-codex-max
+                        - openai/gpt-5.1-codex-max:medium
+                        - openai/gpt-5.1-codex-max:high
+                        - openai/gpt-5.1-codex-max:xhigh
+                        - openai/gpt-5.2
+                        - openai/gpt-5.2:medium
+                        - openai/gpt-5.2:high
+                        - openai/gpt-5.2:xhigh
+                        - openai/gpt-5.2-codex
+                        - openai/gpt-5.2-codex:medium
+                        - openai/gpt-5.2-codex:high
+                        - openai/gpt-5.2-codex:xhigh
+                        - openai/gpt-5.3-codex
+                        - openai/gpt-5.3-codex:medium
+                        - openai/gpt-5.3-codex:high
+                        - openai/gpt-5.3-codex:xhigh
+                        - openai/gpt-5.3-chat
+                        - openai/gpt-5.4
+                        - openai/gpt-5.4:medium
+                        - openai/gpt-5.4:high
+                        - openai/gpt-5.4:xhigh
+                        - openai/gpt-5.4-pro
+                        - openai/gpt-5.4-pro:medium
+                        - openai/gpt-5.4-pro:high
+                        - openai/gpt-5.4-pro:xhigh
+                        - openai/gpt-5.4-mini
+                        - openai/gpt-5.4-nano
+                        - openai/gpt-5.5
+                        - openai/gpt-5.5:medium
+                        - openai/gpt-5.5:high
+                        - openai/gpt-5.5:xhigh
+                        - openai/gpt-5.5-pro
+                        - openai/gpt-5.5-pro:medium
+                        - openai/gpt-5.5-pro:high
+                        - openai/gpt-5.5-pro:xhigh
                   required:
                     - type
                     - name
@@ -612,9 +994,179 @@ components:
                     name:
                       type: string
                       enum:
+                        - anthropic/claude-4.0-sonnet
+                        - anthropic/claude-4.0-opus
+                        - anthropic/claude-sonnet-4.5
+                        - anthropic/claude-sonnet-4.5:thinking
+                        - anthropic/claude-haiku-4.5
+                        - anthropic/claude-haiku-4.5:thinking
+                        - anthropic/claude-opus-4.5
+                        - anthropic/claude-opus-4.5:thinking
+                        - anthropic/claude-opus-4.8
+                        - anthropic/claude-opus-4.8:thinking
+                        - anthropic/claude-fable-5
+                        - anthropic/claude-fable-5:thinking
+                        - anthropic/claude-opus-4.7
+                        - anthropic/claude-opus-4.7:thinking
+                        - anthropic/claude-opus-4.6
+                        - anthropic/claude-opus-4.6:thinking
+                        - anthropic/claude-sonnet-5
+                        - anthropic/claude-sonnet-5:thinking
+                        - anthropic/claude-sonnet-4.6
+                        - anthropic/claude-sonnet-4.6:thinking
                         - anthropic/claude-3.5-sonnet
                         - anthropic/claude-3.5-haiku
                         - anthropic/claude-3.7-sonnet
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - google
+                    name:
+                      type: string
+                      enum:
+                        - google/gemini-2.5-pro
+                        - google/gemini-2.5-flash
+                        - google/gemini-2.5-flash-lite
+                        - google/gemini-3-pro-preview
+                        - google/gemini-3-flash-preview
+                        - google/gemini-3-flash
+                        - google/gemini-3.1-pro-preview
+                        - google/gemini-3.1-flash-lite-preview
+                        - google/gemini-3.1-flash-lite
+                        - google/gemini-3.5-flash
+                        - google/gemma-4-31b-it
+                        - google/gemma-4-26b-a4b-it
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - alibaba
+                    name:
+                      type: string
+                      enum:
+                        - alibaba/qwen3.7-plus
+                        - alibaba/qwen3.6-plus
+                        - alibaba/qwen3.6-27b
+                        - alibaba/qwen-3.6-max-preview
+                        - alibaba/qwen3.7-max
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - minimax
+                    name:
+                      type: string
+                      enum:
+                        - minimax/minimax-m3
+                        - minimax/minimax-m2.7
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - zai
+                    name:
+                      type: string
+                      enum:
+                        - zai/glm-5.1
+                        - zai/glm-5.2
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - moonshotai
+                    name:
+                      type: string
+                      enum:
+                        - moonshotai/kimi-k2.6
+                        - moonshotai/kimi-k2.7-code
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - deepseek
+                    name:
+                      type: string
+                      enum:
+                        - deepseek/deepseek-v4-pro
+                        - deepseek/deepseek-v4-flash
+                        - deepseek/deepseek-v4-pro:high
+                        - deepseek/deepseek-v4-pro:max
+                        - deepseek/deepseek-v4-flash:max
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - xai
+                    name:
+                      type: string
+                      enum:
+                        - xai/grok-4.3
+                        - xai/grok-build-0.1
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - xiaomi
+                    name:
+                      type: string
+                      enum:
+                        - xiaomi/mimo-v2.5
+                        - xiaomi/mimo-v2.5-pro
+                  required:
+                    - type
+                    - name
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - nvidia
+                    name:
+                      type: string
+                      enum:
+                        - nvidia/nemotron-3-ultra-550b-a55b
                   required:
                     - type
                     - name
@@ -636,6 +1188,7 @@ paths:
         - Workspace
       description: Create a project in a workspace
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -651,7 +1204,6 @@ paths:
                 - contentType
                 - content
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -903,6 +1455,7 @@ paths:
         - Project
       description: Copy a project to a folder
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -917,7 +1470,6 @@ paths:
               required:
                 - folderId
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -956,6 +1508,7 @@ paths:
         - Project
       description: Create a project in a team
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -975,7 +1528,6 @@ paths:
                 - contentType
                 - content
               additionalProperties: false
-        required: true
       responses:
         "200":
           description: Successful Project creation
@@ -1008,6 +1560,7 @@ paths:
         - Project
       description: Create a project from a custom template
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1023,7 +1576,6 @@ paths:
                 - folderId
                 - templateId
               additionalProperties: false
-        required: true
       responses:
         "200":
           description: Successful Project creation from template
@@ -1232,19 +1784,17 @@ paths:
           required: false
         - schema:
             type: string
-            format: uuid
           in: query
           name: after
           required: false
-          description: Parameter for cursor-based pagination. Specify task ID to get
+          description: Parameter for cursor-based pagination. Specify block ID to get
             blocks after it. Do not specify both before and after.
         - schema:
             type: string
-            format: uuid
           in: query
           name: before
           required: false
-          description: Parameter for cursor-based pagination. Specify task ID to get
+          description: Parameter for cursor-based pagination. Specify block ID to get
             blocks before it. Do not specify both before and after.
         - schema:
             type: string
@@ -1287,13 +1837,13 @@ paths:
       parameters:
         - schema:
             type: number
+            maximum: 1000
             default: 100
           in: query
           name: limit
           required: false
         - schema:
             type: string
-            format: uuid
           in: query
           name: after
           required: false
@@ -1301,7 +1851,6 @@ paths:
             after it. Do not specify both before and after.
         - schema:
             type: string
-            format: uuid
           in: query
           name: before
           required: false
@@ -1425,6 +1974,7 @@ paths:
         - Task
       description: Update task.
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1443,7 +1993,6 @@ paths:
                 - contentType
                 - content
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -1575,6 +2124,7 @@ paths:
         - Task
       description: Create one or more tasks in a project
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1631,7 +2181,6 @@ paths:
               required:
                 - tasks
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -1673,6 +2222,7 @@ paths:
         - Task
       description: Move a task within the project
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1698,7 +2248,6 @@ paths:
               required:
                 - target
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -1785,6 +2334,7 @@ paths:
         - Task
       description: Task assignment
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -1798,7 +2348,6 @@ paths:
               required:
                 - handles
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -1994,6 +2543,7 @@ paths:
         - Task
       description: Create or update date for a task
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2006,7 +2556,6 @@ paths:
               required:
                 - start
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -2093,6 +2642,7 @@ paths:
         - Task
       description: Add/update a note to the task
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2111,7 +2661,6 @@ paths:
                 - type
                 - value
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -2320,6 +2869,7 @@ paths:
         - Task
       description: Update/create the field value of a task
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2333,7 +2883,6 @@ paths:
               required:
                 - value
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -2419,6 +2968,7 @@ paths:
         - Folder
       description: Generate agent based on input text prompts
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2429,7 +2979,6 @@ paths:
               required:
                 - text
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -2467,6 +3016,7 @@ paths:
         - Folder
       description: Create an agent in a team or workspace.
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -2568,6 +3118,42 @@ paths:
                                 - ViralAgent
                                 - SOPOnboardingAgent
                                 - PressReleaseAgent
+                                - Designer
+                                - Brainstormer
+                                - Builder
+                                - ResearchAnalyst
+                                - OperationsManager
+                                - CodeReviewer
+                                - LeadScorer
+                                - ContactEnricher
+                                - ContentStrategist
+                                - DealMover
+                                - Estimator
+                                - DigitalTwin
+                                - WatchFloorBriefer
+                                - AnomalySpotter
+                                - RestockAdvisor
+                                - AppDoctor
+                                - RenewalChaser
+                                - WinBackSpecialist
+                                - NoShowRescuer
+                                - AbandonedCartRecoverer
+                                - ReviewResponder
+                                - TestimonialHarvester
+                                - SponsorshipManager
+                                - CourseLaunchStrategist
+                                - CurriculumAuthor
+                                - PersonalizedRoadmapGenerator
+                                - DispatchCoordinator
+                                - ProviderNetworkBuilder
+                                - ClaimsClerk
+                                - ListingMarketer
+                                - GrantWriter
+                                - ComplianceKeeper
+                                - LeadQualifier
+                                - ClientOnboardingConcierge
+                                - PipelineReporter
+                                - LearnerCoach
                             avatar:
                               $ref: "#/components/schemas/SpaceAgent/properties/data/properties/avatar"
                           required:
@@ -2581,7 +3167,6 @@ paths:
                 - name
                 - data
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -2941,6 +3526,7 @@ paths:
         - Agent
       description: Update agent
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3104,6 +3690,8 @@ paths:
                                 text:
                                   type: string
                                   minLength: 1
+                                prompt:
+                                  type: string
                               required:
                                 - id
                                 - text
@@ -3136,7 +3724,41 @@ paths:
                                 type: string
                               description:
                                 type: string
+                              image:
+                                allOf:
+                                  - $ref: "#/paths/~1agents~1{agentId}~1public-agent/get/responses/200/content/application~1json/schema/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file"
+                                nullable: true
                             additionalProperties: false
+                          color:
+                            type: string
+                          launcherIcon:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - emoji
+                                  value:
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - type
+                                  - value
+                                additionalProperties: false
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - custom
+                                  image:
+                                    $ref: "#/paths/~1agents~1{agentId}~1public-agent/get/responses/200/content/application~1json/schema/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file"
+                                required:
+                                  - type
+                                  - image
+                                additionalProperties: false
+                            nullable: true
                         additionalProperties: false
                     required:
                       - id
@@ -3165,6 +3787,7 @@ paths:
         - Agent
       description: Update public agent
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3197,12 +3820,97 @@ paths:
                           type: string
                         description:
                           type: string
+                        image:
+                          type: object
+                          properties:
+                            ownerID:
+                              type: string
+                            ownerType:
+                              type: string
+                              minLength: 1
+                              nullable: true
+                            id:
+                              type: string
+                            namespace:
+                              type: string
+                            extension:
+                              type: string
+                            s3KeyOriginal:
+                              type: string
+                            userID:
+                              type: number
+                              nullable: true
+                            spaceID:
+                              type: string
+                              minLength: 1
+                              nullable: true
+                            documentID:
+                              type: string
+                              minLength: 1
+                              nullable: true
+                            nodeID:
+                              type: string
+                              minLength: 1
+                              nullable: true
+                            size:
+                              type: number
+                            mimetype:
+                              type: string
+                            metadata:
+                              type: object
+                              properties: {}
+                              additionalProperties: true
+                            type:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                          required:
+                            - ownerID
+                            - id
+                            - namespace
+                            - extension
+                            - s3KeyOriginal
+                            - size
+                            - mimetype
+                          additionalProperties: true
+                          nullable: true
                       additionalProperties: false
+                    color:
+                      type: string
+                    launcherIcon:
+                      anyOf:
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - emoji
+                            value:
+                              type: string
+                              minLength: 1
+                          required:
+                            - type
+                            - value
+                          additionalProperties: false
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - custom
+                            image:
+                              $ref: "#/paths/~1agents~1{agentId}~1public-agent/patch/requestBody/content/application~1json/schema/properties/preferences/properties/meta/properties/image"
+                          required:
+                            - type
+                            - image
+                          additionalProperties: false
+                      nullable: true
                   additionalProperties: false
               required:
                 - preferences
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -3317,6 +4025,8 @@ paths:
                                 text:
                                   type: string
                                   minLength: 1
+                                prompt:
+                                  type: string
                               required:
                                 - id
                                 - text
@@ -3349,7 +4059,41 @@ paths:
                                 type: string
                               description:
                                 type: string
+                              image:
+                                allOf:
+                                  - $ref: "#/paths/~1agents~1{agentId}~1public-agent/patch/responses/200/content/application~1json/schema/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file"
+                                nullable: true
                             additionalProperties: false
+                          color:
+                            type: string
+                          launcherIcon:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - emoji
+                                  value:
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - type
+                                  - value
+                                additionalProperties: false
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - custom
+                                  image:
+                                    $ref: "#/paths/~1agents~1{agentId}~1public-agent/patch/responses/200/content/application~1json/schema/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file"
+                                required:
+                                  - type
+                                  - image
+                                additionalProperties: false
+                            nullable: true
                         additionalProperties: false
                     required:
                       - id
@@ -3375,6 +4119,7 @@ paths:
         - Agent
       description: Create a knowledge project
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3385,7 +4130,6 @@ paths:
               required:
                 - projectId
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -3424,6 +4168,7 @@ paths:
         - Agent
       description: Create a knowledge media
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -3434,7 +4179,6 @@ paths:
               required:
                 - mediaId
               additionalProperties: false
-        required: true
       parameters:
         - schema:
             type: string
@@ -3709,6 +4453,337 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /medias/{mediaId}/download:
+    get:
+      operationId: mediaDownload
+      tags:
+        - Media
+      description: Download the binary content of a media file. Returns the file with
+        the original Content-Type and Content-Disposition headers.
+      parameters:
+        - schema:
+            type: string
+          in: path
+          name: mediaId
+          required: true
+          description: The SpaceMedia record ID.
+      responses:
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /medias/spaces/{spaceId}/download:
+    get:
+      operationId: mediaDownloadAll
+      tags:
+        - Media
+      description: Download all media files from a space as a ZIP archive. Each file
+        is stored as {mediaId}/metadata.json (id, kind, name, mimetype, size)
+        and {mediaId}/original (binary content).
+      parameters:
+        - schema:
+            type: string
+          in: path
+          name: spaceId
+          required: true
+          description: The space (subspace / app) ID to download all media from.
+      responses:
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /medias/spaces/{spaceId}/upload:
+    post:
+      operationId: mediaUpload
+      tags:
+        - Media
+      description: Upload a media file to a space (root workspace or subspace / app).
+        Send the file as the raw request body with the appropriate Content-Type
+        header (e.g. image/png, application/pdf, application/octet-stream). Pass
+        the original filename as the `filename` query parameter.
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: filename
+          required: true
+          description: Original filename of the uploaded file (e.g. "photo.png").
+        - schema:
+            type: string
+          in: path
+          name: spaceId
+          required: true
+          description: The space ID to upload media into (can be a root workspace or a
+            subspace / app).
+      responses:
+        "200":
+          description: Uploaded media file details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - true
+                  item:
+                    type: object
+                    properties:
+                      mediaId:
+                        type: string
+                        description: The SpaceMedia record ID (UUID).
+                      fileId:
+                        type: string
+                        description: The file ID used in S3 (e.g. "space-files/uuid").
+                      kind:
+                        type: string
+                        description: Detected media kind (image, video, audio, document, etc.).
+                      downloadUrl:
+                        type: string
+                        description: Public URL to download the uploaded file.
+                    required:
+                      - mediaId
+                      - fileId
+                      - kind
+                      - downloadUrl
+                    additionalProperties: false
+                required:
+                  - ok
+                  - item
+                additionalProperties: false
+                description: Uploaded media file details
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /bundles/{spaceId}/export:
+    get:
+      operationId: bundleExport
+      tags:
+        - Bundle
+      description: Export a space (subspace / app) as a JSON bundle (SpaceBundleData
+        v1). Returns all agents, automations, projects, templates, and apps.
+        Media items are excluded — use the ZIP export or download media
+        separately via the media endpoints.
+      parameters:
+        - schema:
+            type: string
+          in: path
+          name: spaceId
+          required: true
+          description: The space (subspace / app) ID to export.
+      responses:
+        "200":
+          description: Exported workspace bundle
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - true
+                  item:
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                        enum:
+                          - "1"
+                        description: Bundle format version.
+                      items:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                          required:
+                            - type
+                          additionalProperties: true
+                        description: "Map of bundle items keyed by ID. Each item has a `type` field:
+                          space-bundle-flow-item, space-bundle-project-item,
+                          space-bundle-agent-item, space-bundle-template-item,
+                          space-bundle-media-item, space-bundle-app-item."
+                    required:
+                      - version
+                      - items
+                    additionalProperties: false
+                    description: SpaceBundleData v1 — Workspace DNA bundle.
+                required:
+                  - ok
+                  - item
+                additionalProperties: false
+                description: Exported workspace bundle
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /bundles/{spaceId}/export/zip:
+    get:
+      operationId: bundleExportZip
+      tags:
+        - Bundle
+      description: Export a space (subspace / app) as a ZIP bundle containing all
+        agents, automations, projects, templates, apps, and media files. The ZIP
+        includes a manifest.json, individual item files in type directories, and
+        media files downloaded from storage.
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - zip
+              - tsk
+            default: zip
+          in: query
+          name: format
+          required: false
+          description: 'Export format: "zip" (default) or "tsk" (.tsk app kit).'
+        - schema:
+            type: string
+          in: path
+          name: spaceId
+          required: true
+          description: The space (subspace / app) ID to export.
+      responses:
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /bundles/{workspaceId}/import:
+    post:
+      operationId: bundleImport
+      tags:
+        - Bundle
+      description: Import a JSON bundle (agents, automations, projects, templates,
+        apps) into a workspace. The bundle is validated against the
+        SpaceBundleData v1 schema and all items are installed into the target
+        workspace. Media items are not supported — use the ZIP import or upload
+        media separately via the media endpoints after import.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bundleData:
+                  type: object
+                  properties:
+                    version:
+                      type: string
+                      enum:
+                        - "1"
+                      description: Bundle format version.
+                    items:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                        required:
+                          - type
+                        additionalProperties: true
+                      description: "Map of bundle items keyed by ID. Each item has a `type` field:
+                        space-bundle-flow-item, space-bundle-project-item,
+                        space-bundle-agent-item, space-bundle-template-item,
+                        space-bundle-media-item, space-bundle-app-item."
+                  required:
+                    - version
+                    - items
+                  additionalProperties: false
+                  description: The Workspace DNA bundle to import (SpaceBundleData v1).
+              required:
+                - bundleData
+              additionalProperties: false
+      parameters:
+        - schema:
+            type: string
+          in: path
+          name: workspaceId
+          required: true
+          description: The target workspace ID to import the bundle into.
+      responses:
+        "200":
+          description: Successful bundle import
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - true
+                  item:
+                    $ref: "#/components/schemas/BundleInstallation"
+                required:
+                  - ok
+                  - item
+                additionalProperties: false
+                description: Successful bundle import
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /bundles/{workspaceId}/import/zip:
+    post:
+      operationId: bundleImportZip
+      tags:
+        - Bundle
+      description: "Import a ZIP/.tsk bundle (exported from the export/zip endpoint)
+        into a workspace. All items are installed into the target workspace. The
+        ZIP must contain valid bundle data (either bundle.json or directory
+        structure). Media files in the ZIP are re-uploaded to storage
+        automatically. Send the file as the raw request body with Content-Type:
+        application/zip, application/octet-stream, or application/x-tsk."
+      parameters:
+        - schema:
+            type: string
+          in: path
+          name: workspaceId
+          required: true
+          description: The target workspace ID to import the bundle into.
+      responses:
+        "200":
+          description: Successful ZIP bundle import
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - true
+                  item:
+                    $ref: "#/components/schemas/BundleInstallation"
+                required:
+                  - ok
+                  - item
+                additionalProperties: false
+                description: Successful ZIP bundle import
+        4XX:
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /public-agents/{publicAgentId}:
     get:
       operationId: publicAgentGet
@@ -3829,6 +4904,8 @@ paths:
                                 text:
                                   type: string
                                   minLength: 1
+                                prompt:
+                                  type: string
                               required:
                                 - id
                                 - text
@@ -3861,7 +4938,41 @@ paths:
                                 type: string
                               description:
                                 type: string
+                              image:
+                                allOf:
+                                  - $ref: "#/paths/~1public-agents~1{publicAgentId}/get/responses/200/content/application~1json/schema/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file"
+                                nullable: true
                             additionalProperties: false
+                          color:
+                            type: string
+                          launcherIcon:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - emoji
+                                  value:
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - type
+                                  - value
+                                additionalProperties: false
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - custom
+                                  image:
+                                    $ref: "#/paths/~1public-agents~1{publicAgentId}/get/responses/200/content/application~1json/schema/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file"
+                                required:
+                                  - type
+                                  - image
+                                additionalProperties: false
+                            nullable: true
                         additionalProperties: false
                     required:
                       - id


### PR DESCRIPTION
> **Stacked PR** — based on `feat/v2-webhook-crud-tools` (signed webhook tools, 62 → 66). Merge that first; this PR's own diff is the last commit.

Partially addresses #12.

## What

Refreshes the vendored v1 OpenAPI spec — **14 months stale** (last synced 2025-05, live spec now has **64 operations vs the vendored 57**) — and enables the two JSON space-bundle operations as tools:

| Tool | Op | Endpoint | Hints |
| --- | --- | --- | --- |
| `bundleExport` | `GET /bundles/{spaceId}/export` | Export a space (subspace / app) as a SpaceBundleData v1 JSON bundle — agents, automations, projects, templates, apps (media excluded) | `readOnlyHint: true` |
| `bundleImport` | `POST /bundles/{workspaceId}/import` | Validate a SpaceBundleData v1 bundle and install all items into the target workspace | write, non-destructive |

**66 → 68 tools** (59 v1 + 9 v2). Bundles are the "Workspace DNA" format behind Genesis `.tsk` app kits (the ZIP export endpoint supports `format=tsk`).

**Not enabled** (out of scope — raw binary request/response bodies need a handwritten wrapper, MCP tools here are JSON-only): `bundleExportZip`, `bundleImportZip`, `mediaUpload`, `mediaDownload`, `mediaDownloadAll`.

**Plan-quota note:** `bundleImport` installs projects/agents/automations into the target workspace; the API enforces plan limits server-side, so an over-quota import failing with a `4XX` error is expected behavior, not a tool bug. The spec documents a generic `4XX` error response for both ops. (The spec makes no claim about secret handling in exports, so the README doesn't either.)

## Upstream spec-generator bug: 12 malformed `$ref`s (patched here, to be filed internally)

The live YAML from `https://www.taskade.com/api/documentation/v1/yaml` contains 12 `$ref`s that are **relative to the enclosing JSON-schema root instead of the OpenAPI document root** (they start with `#/properties/...`). They crash `@readme/openapi-parser` with `MissingPointerError`, so `yarn build` fails on the raw fetch. This PR patches each to the equivalent absolute pointer (resolved against the nearest ancestor node where the pointer is valid — verified unique for all 12). A fully-dereferenced deep-compare of the patched spec vs an independently patched copy (inlining instead of repointing) is byte-identical, and the full v1 codegen runs clean.

Until the upstream generator is fixed, re-running `yarn fetch:openapi` will re-introduce the broken refs — the 12 patches below must be re-applied after any refetch.

| # | Location (JSON pointer) | Malformed `$ref` |
| --- | --- | --- |
| 1 | `components/schemas/Field/…/fillerConfig/anyOf/1/properties/sourceRef` | `#/properties/data/anyOf/1/properties/fillerConfig/anyOf/0/properties/sourceRef` |
| 2 | `components/schemas/Field/…/fillerConfig/anyOf/2/properties/sourceRef` | same as 1 |
| 3 | `components/schemas/Field/…/fillerConfig/anyOf/4/properties/sourceRef` | same as 1 |
| 4 | `components/schemas/Field/properties/data/anyOf/5/properties/fillerConfig` | `#/properties/data/anyOf/1/properties/fillerConfig` |
| 5 | `components/schemas/Field/properties/data/anyOf/7/properties/fillerConfig` | same as 4 |
| 6 | `GET /agents/{agentId}/public-agent` 200 → `…/preferences/meta/image/allOf/0` | `#/properties/item/properties/data/properties/avatar/anyOf/0/properties/data/properties/file` |
| 7 | `GET /agents/{agentId}/public-agent` 200 → `…/preferences/launcherIcon/anyOf/1/image` | same as 6 |
| 8 | `PATCH /agents/{agentId}/public-agent` requestBody → `…/preferences/launcherIcon/anyOf/1/image` | `#/properties/preferences/properties/meta/properties/image` |
| 9 | `PATCH /agents/{agentId}/public-agent` 200 → `…/preferences/meta/image/allOf/0` | same as 6 |
| 10 | `PATCH /agents/{agentId}/public-agent` 200 → `…/preferences/launcherIcon/anyOf/1/image` | same as 6 |
| 11 | `GET /public-agents/{publicAgentId}` 200 → `…/preferences/meta/image/allOf/0` | same as 6 |
| 12 | `GET /public-agents/{publicAgentId}` 200 → `…/preferences/launcherIcon/anyOf/1/image` | same as 6 |

(5 under `components/schemas/Field`, 7 under the `/agents/{agentId}/public-agent` + `/public-agents/{publicAgentId}` paths.)

## Schema drift in existing tools (intended — this PR is not additive-only)

Regenerating from the fresh spec updates the input schemas of **6 existing tools** (a year of Field/Block/Task/Date/SpaceAgent evolution):

| Tool | Drift |
| --- | --- |
| `projectBlocksGet` | pagination cursors `after`/`before` lose `.uuid()` (now plain strings) |
| `projectTasksGet` | same cursor change + `limit` gains `.lte(1000)` |
| `taskPutDate` | `Date` schema: `date`/`time` gain format descriptions; `timezone` (IANA) documented on start/end |
| `folderCreateAgent` | SpaceAgent: new persona enum values (`Designer`, `Brainstormer`, `Builder`, `ResearchAnalyst`, …), skill `description` field, `inputPlaceholder` now nullable |
| `agentUpdate` | same SpaceAgent evolution |
| `agentPublicUpdate` | public-agent preferences drift (nullable fields, richer descriptions) |

Two tools the drift was expected to touch — `agentPublicGet`, `publicAgentGet` — are unchanged: their inputs are path-params only, and their drift (the avatar/file response schemas, incl. refs 6–12 above) lives in response schemas, which MCP tool definitions don't embed.

## Assertions

- **A1 (name-set diff vs base):** 57 → 59 v1 tools; added exactly `["bundleExport","bundleImport"]`; removed `[]`; zero renames. `bundleExport` has `readOnlyHint: true`.
- **A2 (schema drift):** exactly the 6 tools tabled above changed; the two "missing" expected tools are explained (response-side drift only).
- **A3 (dereference proof):** `tsx scripts/gen-taskade-mcp-tools.ts` completes with no `MissingPointerError`; `yarn build` → `Lerna (powered by Nx)   Successfully ran target build for project @taskade/mcp-server`, and a post-commit rebuild leaves `git status --porcelain` empty. Dereferenced patched spec is deep-equal to the independently verified fixed spec.
- **A4 (count consistency):** `git grep -nE '6[26] tools'` finds no live claims (only the previous PR's own changeset entry "62 → 66 tools", which is that change's accurate history); "68 tools" present in root `README.md` (3×), `packages/server/README.md`, and `server.json`.

## CI gates

`yarn build` (regen both tool files + esbuild + lint:fix, tree stays clean) · `yarn lint` · `yarn test` (23/23) — all green locally.

## Manual live-QA checklist (needs a real `TASKADE_API_KEY`)

- [ ] `bundleExport` a small test space → response `ok: true`, `item.version === "1"`, `item.items` keyed map with `space-bundle-*-item` types
- [ ] `bundleImport` that bundle into a scratch workspace → `ok: true` + `BundleInstallation` counts match the exported items
- [ ] Verify the round-tripped projects/agents/automations open correctly in the scratch workspace
- [ ] Over-quota import on a free workspace → clean `4XX` error surfaced as a tool error (not a crash)
