### PR TITLE
fix(ci): wire NPM_TOKEN into publish steps (OIDC trusted publishing never configured npm-side)

### DIFF
--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -32,4 +32,7 @@ jobs:
         run: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # OIDC trusted publishing was never configured on npmjs.com (this
+          # workflow has failed on every dispatch since Feb 2026). Token fallback:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,8 @@ jobs:
         run: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # OIDC trusted publishing was never configured on npmjs.com, so every
+          # tokenless publish fails E404-on-PUT (provenance signs, PUT rejects).
+          # NODE_AUTH_TOKEN feeds the .npmrc written by setup-node's registry-url.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

Today's 0.1.2 release run failed at Publish with **E404 on PUT** for both packages. Diagnosis:

- npm **OIDC trusted publishing was never configured on npmjs.com** — `force-release.yml` has failed on **every dispatch since Feb 2026** (runs 22002394603, 22002491927, 26078540906, 27230718079), and the June 0.1.0/0.1.1 publishes were manual token publishes from a maintainer machine, which masked this.
- A repo secret `NPM_TOKEN` exists (updated 2026-05-19) but **no workflow ever referenced it** — the Publish steps had no `NODE_AUTH_TOKEN`, so npm had no credentials and the registry returned its unauthorized-as-404.

## Fix

Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the Publish steps of `release.yml` and `force-release.yml`. `actions/setup-node` with `registry-url` already writes an `.npmrc` that reads `NODE_AUTH_TOKEN`; provenance still signs via the existing `id-token: write` + `NPM_CONFIG_PROVENANCE`.

If/when trusted publishing is configured on npmjs.com for both packages, the token fallback can be removed.

## Test plan
- Merge → `release.yml` runs on the push; with no pending changesets it goes straight to Publish → expect `@taskade/mcp-server@0.1.2` + `@taskade/mcp-openapi-codegen@0.0.6` on npm and git tags pushed (which trigger the MCP-registry publish).
- If the stored token itself is invalid, the run fails the same way and the remaining fix is npm-side (add trusted publisher or mint a fresh automation token) — documented in the run comment.