### PR TITLE
docs(docker): count-free image label — kill the tool-count drift class

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-slim
 
 LABEL maintainer="Taskade <support@taskade.com>"
-LABEL description="Taskade MCP Server — 62 AI tools for project management via Model Context Protocol"
+LABEL description="Taskade MCP Server — AI tools for projects, tasks, agents, and webhooks via Model Context Protocol"
 LABEL org.opencontainers.image.source="https://github.com/taskade/mcp"
 LABEL org.opencontainers.image.licenses="MIT"
 


### PR DESCRIPTION
The Dockerfile LABEL has gone stale twice (57 → 62 in #67; would be 68 after #71). Low-traffic surfaces shouldn't carry counts at all — the canonical count lives in README.md and server.json, which the tool-wave PRs keep updated. One-line change, no behavior impact.