### PR TITLE
feat(registry): list the hosted OAuth server alongside the npm package

### DIFF
--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -1,12 +1,20 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.taskade/mcp-server",
-  "description": "Connect Taskade to any AI assistant — 62 tools: projects, tasks, agents, agent chat, webhooks.",
+  "title": "Taskade",
+  "description": "Taskade in any AI assistant — projects, tasks, agents, agent chat, automations, webhooks.",
+  "websiteUrl": "https://www.taskade.com/mcp",
   "repository": {
     "url": "https://github.com/taskade/mcp.git",
     "source": "github"
   },
   "version": "0.1.1",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.taskade.com/mcp"
+    }
+  ],
   "packages": [
     {
       "registryType": "npm",


### PR DESCRIPTION
Fixes #77.

## The gap

The MCP Registry entry for `io.github.taskade/mcp-server` described **only the stdio npm package** — install `@taskade/mcp-server`, mint a `TASKADE_API_KEY`, paste the secret into a config file. The hosted server at `https://www.taskade.com/mcp` (OAuth 2.0 + PKCE + DCR, RFC 9728/8414 discovery, nothing to install) had no `remotes` entry, so every registry consumer saw the harder onboarding path and never learned the easier one exists.

## The decision (from #77's open question)

**One entry with both `remotes` and `packages` — not two entries.** Rationale:

- They are one product reached over two transports; the registry data model exists precisely to express that. Two near-identical "Taskade" rows in every client gallery is worse discovery, not better.
- The hosted remote is listed **first**: it is the right default for the overwhelming majority of users (nothing to install, no long-lived secret), with the npm package remaining the self-hosted/power-user lane.
- The one casualty of sharing an entry was the `description`'s "62 tools", which was only true of the npm package — the hosted server exposes a different, smaller toolset. The description is now **numberless and capability-based** ("projects, tasks, agents, agent chat, automations, webhooks", 89/100 chars), so it is accurate for both transports and cannot silently go stale as either toolset evolves. This also matches the house rule in the main repos: never ship a bare tool count you cannot re-derive.

## Diff

```json
  "title": "Taskade",
  "description": "Taskade in any AI assistant — projects, tasks, agents, agent chat, automations, webhooks.",
  "websiteUrl": "https://www.taskade.com/mcp",
  "remotes": [
    { "type": "streamable-http", "url": "https://www.taskade.com/mcp" }
  ],
```

(`websiteUrl` points at the endpoint itself because it doubles as a human discovery page when fetched with `Accept: text/html`.)

## Verified

- **Schema**: validated against the official `2025-12-11` `server.schema.json` — `remotes`/`title`/`websiteUrl` are legal `ServerDetail` keys, the streamable-http URL matches the required pattern, description within the 100-char limit, no unknown top-level keys. Live entries already use this exact shape (e.g. `ac.inference.sh/mcp`).
- **CI-safe**: ran `.github/workflows/publish-mcp-registry.yml`'s version-sync one-liner against this file verbatim — it rewrites only `version` and `packages[].version`; `remotes`, `title`, and `websiteUrl` survive untouched.
- **Endpoint contract is live**:
  ```
  $ curl -sI https://www.taskade.com/mcp
  HTTP/2 401
  www-authenticate: Bearer realm="mcp", resource_metadata="https://www.taskade.com/mcp/.well-known/oauth-protected-resource"
  ```
  Both RFC 9728 path forms return 200 with correct metadata.

## Publishing

No new pipeline, no DNS, no secrets. Ships through the existing OIDC workflow on the next `@taskade/mcp-server@*` release tag (`package.json` is already at the unreleased `0.1.2`, pending the npm Trusted Publisher fix in #74) — or immediately via the workflow's manual `workflow_dispatch` re-publish lane.